### PR TITLE
ci: remove obsolete dependabot target-branch settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: "/"
-    target-branch: "railway"
     schedule:
       interval: weekly
       day: monday
@@ -23,7 +22,6 @@ updates:
 
   - package-ecosystem: npm
     directory: "/backend"
-    target-branch: "railway"
     schedule:
       interval: weekly
       day: monday
@@ -44,7 +42,6 @@ updates:
 
   - package-ecosystem: npm
     directory: "/workers"
-    target-branch: "railway"
     schedule:
       interval: weekly
       day: monday
@@ -65,7 +62,6 @@ updates:
 
   - package-ecosystem: github-actions
     directory: "/"
-    target-branch: "railway"
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
## Summary
- Remove  from Dependabot config
- Keep regular version updates disabled
- Keep security grouping behavior unchanged

## Reason
- Security updates do not follow 
- Interact with Railway via CLI

Usage: railway [COMMAND]

Commands:
  add            Add a service to your project
  completion     Generate completion script
  connect        Connect to a database's shell (psql for Postgres, mongosh for MongoDB, etc.)
  delete         Delete a project
  deploy         Provisions a template into your project
  deployment     Manage deployments
  dev            Run Railway services locally [aliases: develop]
  domain         Add a custom domain or generate a railway provided domain for a service
  docs           Open Railway Documentation in default browser
  down           Remove the most recent deployment
  environment    Create, delete or link an environment [aliases: env]
  init           Create a new project
  link           Associate existing project with current directory, may specify projectId as an argument
  list           List all projects in your Railway account
  login          Login to your Railway account
  logout         Logout of your Railway account
  logs           View build or deploy logs from a Railway deployment
  open           Open your project dashboard
  project        Manage projects
  run            Run a local command using variables from the active environment [aliases: local]
  service        Manage services
  shell          Open a local subshell with Railway variables available
  ssh            Connect to a service via SSH
  status         Show information about the current project
  unlink         Disassociate project from current directory
  up             Upload and deploy project from the current directory
  upgrade        Upgrade the Railway CLI to the latest version
  variable       Manage environment variables for a service [aliases: variables, vars, var]
  whoami         Get the current logged in user
  volume         Manage project volumes
  redeploy       Redeploy the latest deployment of a service
  restart        Restart the latest deployment of a service (without rebuilding)
  scale          
  check_updates  Test the update check
  functions      Manage project functions [aliases: function, func, fn, funcs, fns]
  help           Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version branch was recreated for workflow use, but this setting was misleading
