### PR TITLE
Use actions/github-script for audit summary and set outputs via core.setOutput

### DIFF
--- a/.github/workflows/security-moderate-report.yml
+++ b/.github/workflows/security-moderate-report.yml
@@ -27,42 +27,54 @@ jobs:
 
       - name: Build moderate audit summary
         id: summary
-        run: |
-          npm audit --omit=dev --json > audit-report.json || true
-          node <<'NODE'
-          const fs = require('fs');
-          const report = JSON.parse(fs.readFileSync('audit-report.json', 'utf8'));
-          const vulnerabilities = report.vulnerabilities || {};
-          const moderate = Object.entries(vulnerabilities)
-            .filter(([, detail]) => detail && detail.severity === 'moderate')
-            .map(([name, detail]) => {
-              const via = Array.isArray(detail.via)
-                ? detail.via.find((item) => item && typeof item === 'object' && item.title)
-                : null;
-              return {
-                name,
-                range: detail.range || 'unknown',
-                title: via?.title || 'Moderate severity advisory',
-                url: via?.url || '',
-              };
-            });
-          const now = new Date().toISOString();
-          let markdown = `## Moderate dependency vulnerabilities\\n\\nGenerated at: ${now}\\n\\n`;
-          if (moderate.length === 0) {
-            markdown += 'No moderate vulnerabilities found in runtime dependencies.\\n';
-          } else {
-            markdown += `Found **${moderate.length}** moderate vulnerabilities.\\n\\n`;
-            markdown += '| Package | Affected Range | Advisory |\\n';
-            markdown += '| --- | --- | --- |\\n';
-            for (const item of moderate) {
-              const advisory = item.url ? `[${item.title}](${item.url})` : item.title;
-              markdown += `| ${item.name} | ${item.range} | ${advisory} |\\n`;
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+
+            try {
+              execSync('npm audit --omit=dev --json > audit-report.json || true', {
+                stdio: 'inherit',
+                shell: '/bin/bash',
+              });
+            } catch (error) {
+              // Keep workflow resilient: npm audit non-zero exits are expected when vulnerabilities exist.
             }
-          }
-          fs.writeFileSync('moderate-report.md', markdown);
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, `count=${moderate.length}\\n`);
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, `report_path=moderate-report.md\\n`);
-          NODE
+
+            const report = JSON.parse(fs.readFileSync('audit-report.json', 'utf8'));
+            const vulnerabilities = report.vulnerabilities || {};
+            const moderate = Object.entries(vulnerabilities)
+              .filter(([, detail]) => detail && detail.severity === 'moderate')
+              .map(([name, detail]) => {
+                const via = Array.isArray(detail.via)
+                  ? detail.via.find((item) => item && typeof item === 'object' && item.title)
+                  : null;
+                return {
+                  name,
+                  range: detail.range || 'unknown',
+                  title: via?.title || 'Moderate severity advisory',
+                  url: via?.url || '',
+                };
+              });
+
+            const now = new Date().toISOString();
+            let markdown = `## Moderate dependency vulnerabilities\n\nGenerated at: ${now}\n\n`;
+            if (moderate.length === 0) {
+              markdown += 'No moderate vulnerabilities found in runtime dependencies.\n';
+            } else {
+              markdown += `Found **${moderate.length}** moderate vulnerabilities.\n\n`;
+              markdown += '| Package | Affected Range | Advisory |\n';
+              markdown += '| --- | --- | --- |\n';
+              for (const item of moderate) {
+                const advisory = item.url ? `[${item.title}](${item.url})` : item.title;
+                markdown += `| ${item.name} | ${item.range} | ${advisory} |\n`;
+              }
+            }
+
+            fs.writeFileSync('moderate-report.md', markdown);
+            core.setOutput('count', String(moderate.length));
+            core.setOutput('report_path', 'moderate-report.md');
 
       - name: Create or update tracking issue
         if: steps.summary.outputs.count != '0'


### PR DESCRIPTION
### Motivation

- Make the moderate vulnerability report step more robust by handling `npm audit` non-zero exits and simplifying script execution within the workflow. 
- Use the `actions/github-script` runtime to set action outputs reliably instead of manually appending to `GITHUB_OUTPUT`.

### Description

- Replaced the inline `node` heredoc step with an `actions/github-script@v8` step that runs the audit and report generation code. 
- Executes `npm audit --omit=dev --json > audit-report.json || true` via `execSync` and wraps it in a `try/catch` to tolerate non-zero exit codes from `npm audit`. 
- Builds the same `moderate-report.md` from `audit-report.json` and writes it to the workspace. 
- Emits outputs using `core.setOutput('count', ...)` and `core.setOutput('report_path', ...)` instead of writing to the `GITHUB_OUTPUT` file directly.

### Testing

- No automated tests were run for this workflow change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c112ba4d7c832293d769ac0f8bcbf3)