### PR TITLE
fix(ci): key smoke-test concurrency by deployment environment

### DIFF
--- a/.github/workflows/deployment-smoke-test.yml
+++ b/.github/workflows/deployment-smoke-test.yml
@@ -21,9 +21,9 @@ permissions:
   contents: read
   issues: write
 
-# Cancel in-progress runs on same branch (only latest deployment matters)
+# Cancel in-progress runs for the same deployment target environment.
 concurrency:
-  group: smoke-test-${{ github.event.deployment.ref || github.event.deployment.environment || github.event.deployment.sha }}
+  group: smoke-test-${{ github.event.deployment.environment || github.event.deployment.ref || github.event.deployment.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- key smoke-test workflow concurrency by deployment environment first
- prevent stale smoke-test runs (keyed by SHA/tag refs) from surviving newer same-environment deploys
- reduce risk of outdated rollback execution against newer healthy deployments

## Test plan
- [x] npm run ci:remote
- [x] verify workflow change in `.github/workflows/deployment-smoke-test.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)