### PR TITLE
feat(backend): Postgres persistence + Cloudflare R2 daily backup

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,85 @@
+name: Database Backup to Cloudflare R2
+
+# Daily PG dump → upload to Cloudflare R2 (S3-compatible).
+#
+# Required GitHub Secrets:
+#   DATABASE_URL_PUBLIC   Public Railway PG connection string
+#                         (Settings → "Public Networking" → connection URL)
+#   R2_ENDPOINT           https://<account-id>.r2.cloudflarestorage.com
+#   R2_ACCESS_KEY_ID      Cloudflare R2 API token Access Key
+#   R2_SECRET_ACCESS_KEY  Cloudflare R2 API token Secret
+#   R2_BUCKET             Bucket name (e.g. aave-db-backups)
+#
+# Old-backup deletion is intentionally NOT done here — configure an R2 bucket
+# lifecycle rule (Object lifecycle → Delete after 30 days) instead. That way
+# retention is consistent even if a workflow run is ever skipped.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # 03:00 UTC daily
+  workflow_dispatch: {}
+
+concurrency:
+  group: db-backup
+  cancel-in-progress: false
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Install postgresql-client-17
+        run: |
+          set -euo pipefail
+          # Railway provisions PG 17 by default; the pg_dump on ubuntu-latest
+          # is older, which would fail with "server version mismatch".
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSLo /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          . /etc/os-release
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update -y
+          sudo apt-get install -y postgresql-client-17
+          pg_dump --version
+
+      - name: Dump database
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PUBLIC }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DATABASE_URL:-}" ]; then
+            echo "DATABASE_URL_PUBLIC secret is not set" >&2
+            exit 1
+          fi
+          STAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+          FILE="aave-pg-${STAMP}.dump"
+          # -Fc = custom binary format with built-in compression (-Z9)
+          pg_dump "$DATABASE_URL" -Fc -Z9 -f "$FILE"
+          ls -lh "$FILE"
+          echo "BACKUP_FILE=$FILE" >> "$GITHUB_ENV"
+
+      - name: Upload to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID:     ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT:           ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET:             ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          aws s3 cp "$BACKUP_FILE" "s3://${R2_BUCKET}/${BACKUP_FILE}" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --region auto \
+            --no-progress
+
+      - name: Verify upload
+        env:
+          AWS_ACCESS_KEY_ID:     ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT:           ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET:             ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          aws s3 ls "s3://${R2_BUCKET}/${BACKUP_FILE}" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --region auto

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -19,6 +19,8 @@ on:
     - cron: '0 3 * * *'   # 03:00 UTC daily
   workflow_dispatch: {}
 
+permissions: {}
+
 concurrency:
   group: db-backup
   cancel-in-progress: false

--- a/backend/migrations/001_init_persistence.sql
+++ b/backend/migrations/001_init_persistence.sql
@@ -1,0 +1,86 @@
+-- Database persistence schema for Aave market & oracle snapshots.
+-- Apply with:  psql "$DATABASE_URL" -f backend/migrations/001_init_persistence.sql
+--
+-- Notes:
+-- * UNIQUE constraint on (snapshot_ts, reserve_id) lets us re-run the same
+--   batch with ON CONFLICT DO NOTHING after a process restart without
+--   inserting duplicates.
+-- * NUMERIC(40,0) is chosen so raw uint256 wei values fit without overflow.
+-- * incentive_details is JSONB so future incentive sources (merit/merkl/brevis
+--   etc.) can be added without schema migrations.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS market_snapshots (
+    id                          BIGSERIAL PRIMARY KEY,
+    snapshot_ts                 TIMESTAMPTZ NOT NULL,
+    reserve_id                  TEXT        NOT NULL,
+    chain_id                    INTEGER     NOT NULL,
+    chain_name                  TEXT        NOT NULL,
+    market_name                 TEXT        NOT NULL,
+    token_symbol                TEXT        NOT NULL,
+    token_name                  TEXT        NOT NULL,
+    token_address               TEXT        NOT NULL,
+    a_token_address             TEXT,
+    v_token_address             TEXT,
+    decimals                    INTEGER,
+    token_price                 NUMERIC(24, 8),
+    supply_apy                  NUMERIC(12, 6),
+    borrow_apy                  NUMERIC(12, 6),
+    utilization_pct             NUMERIC(8, 4),
+    available_liquidity         NUMERIC(40, 0),
+    total_variable_debt         NUMERIC(40, 0),
+    reserve_size                NUMERIC(40, 0),
+    supply_cap                  NUMERIC(40, 0),
+    borrow_cap                  NUMERIC(40, 0),
+    deficit                     NUMERIC(40, 0),
+    base_variable_borrow_rate   NUMERIC(12, 6),
+    reserve_factor              NUMERIC(8, 4),
+    variable_rate_slope1        NUMERIC(8, 4),
+    variable_rate_slope2        NUMERIC(8, 4),
+    optimal_usage_rate          NUMERIC(8, 4),
+    supply_disabled             BOOLEAN,
+    borrow_disabled             BOOLEAN,
+    is_frozen                   BOOLEAN,
+    is_paused                   BOOLEAN,
+    supply_incentives_apr       NUMERIC(12, 6),
+    borrow_incentives_apr       NUMERIC(12, 6),
+    incentive_details           JSONB,
+    aave_pro_reserve_id         TEXT,
+    hub_id                      TEXT,
+    hub_name                    TEXT,
+    hub_address                 TEXT,
+    spoke_id                    TEXT,
+    spoke_name                  TEXT,
+    spoke_address               TEXT,
+    CONSTRAINT market_snapshots_unique UNIQUE (snapshot_ts, reserve_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_market_snapshots_ts
+    ON market_snapshots (snapshot_ts DESC);
+CREATE INDEX IF NOT EXISTS idx_market_snapshots_reserve_ts
+    ON market_snapshots (reserve_id, snapshot_ts DESC);
+CREATE INDEX IF NOT EXISTS idx_market_snapshots_symbol_ts
+    ON market_snapshots (token_symbol, snapshot_ts DESC);
+CREATE INDEX IF NOT EXISTS idx_market_snapshots_chain_ts
+    ON market_snapshots (chain_id, snapshot_ts DESC);
+
+
+CREATE TABLE IF NOT EXISTS oracle_prices (
+    id              BIGSERIAL PRIMARY KEY,
+    snapshot_ts     TIMESTAMPTZ NOT NULL,
+    chain_id        INTEGER     NOT NULL,
+    token_address   TEXT        NOT NULL,        -- lowercase
+    raw_price       NUMERIC(78, 0) NOT NULL,     -- oracle raw uint256
+    price_usd       NUMERIC(24, 8) NOT NULL,     -- raw_price / 1e8
+    source          TEXT        NOT NULL,        -- 'v3' | 'v4'
+    spoke_address   TEXT,                        -- v4 only
+    CONSTRAINT oracle_prices_unique UNIQUE (snapshot_ts, chain_id, token_address, source, spoke_address)
+);
+
+CREATE INDEX IF NOT EXISTS idx_oracle_prices_ts
+    ON oracle_prices (snapshot_ts DESC);
+CREATE INDEX IF NOT EXISTS idx_oracle_prices_token_ts
+    ON oracle_prices (chain_id, token_address, snapshot_ts DESC);
+
+COMMIT;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,12 +12,14 @@
         "@bgd-labs/aave-address-book": "^4.44.22",
         "@internal/aave-shared-config": "file:../packages/aave-shared-config",
         "@types/compression": "^1.8.1",
+        "@types/pg": "^8.20.0",
         "compression": "^1.8.1",
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "ethers": "^5.8.0",
         "express": "^4.18.2",
         "node-cron": "^4.2.1",
+        "pg": "^8.20.0",
         "winston": "^3.19.0"
       },
       "devDependencies": {
@@ -1493,6 +1495,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -2966,6 +2979,96 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2984,6 +3087,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -3297,6 +3439,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stack-trace": {
@@ -3631,6 +3782,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yaml": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,12 +20,14 @@
     "@bgd-labs/aave-address-book": "^4.44.22",
     "@internal/aave-shared-config": "file:../packages/aave-shared-config",
     "@types/compression": "^1.8.1",
+    "@types/pg": "^8.20.0",
     "compression": "^1.8.1",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "ethers": "^5.8.0",
     "express": "^4.18.2",
     "node-cron": "^4.2.1",
+    "pg": "^8.20.0",
     "winston": "^3.19.0"
   },
   "devDependencies": {

--- a/backend/src/cacheTtl.ts
+++ b/backend/src/cacheTtl.ts
@@ -31,6 +31,8 @@ export const BACKEND_SCHEDULE_CRON = {
   coingeckoCategoriesWarmEverySixHoursAtSecond10: '10 0 */6 * * *',
   // Aligned with merklForecastResultDefault (10 min) for cron-write/API-read-only pattern.
   campaignForecastWarmEveryTenMinutesAtSecond30: '30 */10 * * * *',
+  // Persistence (PostgreSQL): every 5 min at :30s, after markets (:00) + onchain (:10) + oracle (:00) settle.
+  persistenceFlushEveryFiveMinutesAtSecond30: '30 */5 * * * *',
 } as const;
 
 export const BACKEND_CACHE_TTL_MS = {

--- a/backend/src/cacheTtl.ts
+++ b/backend/src/cacheTtl.ts
@@ -25,6 +25,8 @@ export const BACKEND_SCHEDULE_CRON = {
   marketsBackupEveryMinuteAtSecond0: '0 * * * * *',
   // On-chain data refresh: every 1 min at second 10 (per-chain concurrent, 30-min TTL)
   onchainDataWarmEveryMinuteAtSecond10: '10 * * * * *',
+  // Oracle price refresh: every 60s (prices update ~every block; V4 reserveToken 1h cached)
+  oraclePriceWarmEveryMinuteAtSecond0: '0 * * * * *',
   coingeckoFdvWarmEveryFiveMinutesAtSecond5: '5 */5 * * * *',
   coingeckoCategoriesWarmEverySixHoursAtSecond10: '10 0 */6 * * *',
   // Aligned with merklForecastResultDefault (10 min) for cron-write/API-read-only pattern.
@@ -37,6 +39,8 @@ export const BACKEND_CACHE_TTL_MS = {
   marketsHardTtlMs: BACKEND_TIME_MS.fiveMinutes,
   // On-chain data TTL: 30 min (deficit/baseVariableBorrowRate change infrequently)
   onchainTtlMs: BACKEND_TIME_MS.thirtyMinutes,
+  // Oracle price TTL: 60s (prices update ~every block; V4 reserveToken mapping has 1h own TTL)
+  oracleTtlMs: 60_000,
 
   // Merkl forecast family.
   // forecastResult aligned with metricsMin since underlying metrics data won't change faster.

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -1,28 +1,28 @@
-import { execSync } from 'node:child_process';
 import dotenv from 'dotenv';
 import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { parseEnvLinesToObject, injectEnv, tryLoadFromDoppler } from '@internal/aave-shared-config';
 
-// Railway injects env vars natively — no Doppler or .env needed
+// Railway injects env vars natively — no .env needed
 if (process.env.RAILWAY_ENVIRONMENT) {
   console.log(`🚂 Railway environment detected (${process.env.RAILWAY_ENVIRONMENT}), using injected env vars`);
 } else {
-  // 1) Prefer Secret Manager (Doppler) at runtime (no .env on server required)
-  const didLoadFromSecretManager = tryLoadFromDoppler();
+  // 1) Load repo-root .env FIRST (BEFORE @internal/aave-shared-config is imported anywhere)
+  //    This is critical: shared-config reads process.env.INFURA_PROJECT_ID etc. at module top-level.
+  //    If shared-config evaluates before dotenv, private RPC keys are forever undefined.
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+  const repoRoot = resolve(__dirname, '..', '..');
+  const envPath = join(repoRoot, '.env');
 
-  // 2) Fallback: Unified env loading from repo-root `.env` (dev/local)
-  if (!didLoadFromSecretManager) {
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = dirname(__filename);
+  console.log(`📄 Loading .env file: ${envPath}`);
+  dotenv.config({ path: envPath });
+  console.log('✅ Loaded environment variables from .env file');
 
-    // backend/src → backend → repo root
-    const repoRoot = resolve(__dirname, '..', '..');
-    const envPath = join(repoRoot, '.env');
-
-    console.log(`📄 Falling back to .env file: ${envPath}`);
-    dotenv.config({ path: envPath });
-    console.log('✅ Loaded environment variables from .env file');
+  // 2) Optionally try Doppler (production secret manager, won't overwrite already-set env vars)
+  try {
+    const { tryLoadFromDoppler } = await import('@internal/aave-shared-config');
+    tryLoadFromDoppler();
+  } catch {
+    // Doppler not available — .env fallback is sufficient for local dev
   }
 }
-

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -13,6 +13,8 @@ import { refreshOnchainCache } from './services/onchainDataService.js';
 import { refreshOracleCache } from './services/oracleService.js';
 import { logger } from './logger.js';
 import { explainServerListenError } from './startup.js';
+import { closePool } from './services/dbPool.js';
+import { getPersistenceStatus } from './services/persistenceService.js';
 
 const app = express();
 app.set('etag', 'weak');
@@ -87,6 +89,14 @@ const healthHandler = (req: express.Request, res: express.Response) => {
 app.get('/health', healthHandler);
 app.get('/api/health', healthHandler);
 
+// Persistence diagnostics — exposes whether DB writes are happening on schedule.
+// Useful for catching silent persistence failures (the cron writer never throws
+// up the call stack, so without this endpoint a failed DB connection could go
+// unnoticed for days).
+app.get('/api/persistence-status', (_req, res) => {
+  res.json(getPersistenceStatus());
+});
+
 // 启动时预热所有缓存，避免首个请求冷启动
 // 注意：cron 不会在启动时立即执行，所以需要显式 warmup
 // 所有 API 数据现在使用 cron-write/API-read-only 模式
@@ -138,6 +148,29 @@ Promise.allSettled([
       }
       process.exit(1);
     });
+
+    // Graceful shutdown — stop accepting new requests, drain in-flight ones,
+    // then close the DB pool so any open connections to Railway PG are released
+    // cleanly during deploy/restart.
+    let shuttingDown = false;
+    const shutdown = (signal: string) => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      logger.info(`📴 Received ${signal}, shutting down gracefully…`);
+      server.close((err) => {
+        if (err) logger.warn('Error closing HTTP server:', err);
+        closePool()
+          .catch((e) => logger.warn('Error closing DB pool:', e))
+          .finally(() => process.exit(0));
+      });
+      // Hard timeout: force-exit if shutdown stalls (>10s).
+      setTimeout(() => {
+        logger.warn('⏱️  Graceful shutdown timed out, forcing exit');
+        process.exit(1);
+      }, 10_000).unref();
+    };
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
   })
   .catch((error) => {
     logger.error('❌ Startup warmup failed:', error);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,6 +10,7 @@ import { warmCoingeckoCategoriesCache, warmCoingeckoFdvCache } from './controlle
 import { warmCampaignForecastStatesCache } from './controllers/merklForecastController.js';
 import { warmMarketsCache } from './services/marketsService.js';
 import { refreshOnchainCache } from './services/onchainDataService.js';
+import { refreshOracleCache } from './services/oracleService.js';
 import { logger } from './logger.js';
 import { explainServerListenError } from './startup.js';
 
@@ -96,6 +97,9 @@ Promise.allSettled([
   refreshOnchainCache()
     .then(() => logger.info('✅ On-chain cache (deficit, baseRate) warmed on startup'))
     .catch((error) => logger.warn('⚠️  Failed to warm on-chain cache on startup:', error)),
+  refreshOracleCache()
+    .then(() => logger.info('✅ Oracle price cache warmed on startup'))
+    .catch((error) => logger.warn('⚠️  Failed to warm oracle cache on startup:', error)),
   warmMarketsCache()
     .then(() => logger.info('✅ Markets cache warmed on startup'))
     .catch((error) => logger.warn('⚠️  Failed to warm markets on startup:', error)),

--- a/backend/src/services/dbPool.ts
+++ b/backend/src/services/dbPool.ts
@@ -1,0 +1,84 @@
+/**
+ * Postgres connection pool for persistence service.
+ *
+ * Lazily initialised: callers should always go through `getPool()`. If
+ * `DATABASE_URL` is not set, `getPool()` throws — `persistenceService` checks
+ * `isPersistenceEnabled()` first so the absence of the env var is treated as
+ * "persistence disabled" rather than a recurring error.
+ */
+import pg from 'pg';
+import { logger } from '../logger.js';
+
+const { Pool } = pg;
+type PoolType = pg.Pool;
+
+let pool: PoolType | null = null;
+let poolClosed = false;
+
+/**
+ * Returns true when the env is configured for persistence.
+ * Cheap check used to short-circuit the persist path.
+ */
+export function isPersistenceEnabled(): boolean {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+/**
+ * Decide whether to enable TLS for the pg client.
+ *
+ * - Railway internal network (`*.railway.internal`) does NOT support TLS.
+ * - Public Railway endpoints (`*.proxy.rlwy.net`, `*.railway.app`) require TLS
+ *   with a self-signed cert; we accept it via `rejectUnauthorized: false`.
+ * - Allow explicit override via `DATABASE_SSL=true|false`.
+ */
+function resolveSslConfig(connectionString: string): pg.PoolConfig['ssl'] {
+  const explicit = process.env.DATABASE_SSL?.toLowerCase();
+  if (explicit === 'true') return { rejectUnauthorized: false };
+  if (explicit === 'false') return undefined;
+
+  if (/\.railway\.internal/i.test(connectionString)) return undefined;
+  if (/\.proxy\.rlwy\.net|\.railway\.app/i.test(connectionString)) {
+    return { rejectUnauthorized: false };
+  }
+  // Localhost / unknown host: default off.
+  if (/@(localhost|127\.0\.0\.1)/i.test(connectionString)) return undefined;
+  return undefined;
+}
+
+export function getPool(): PoolType {
+  if (poolClosed) {
+    throw new Error('Database pool has been closed (process is shutting down)');
+  }
+  if (pool) return pool;
+
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL environment variable is required for database persistence');
+  }
+
+  pool = new Pool({
+    connectionString,
+    ssl: resolveSslConfig(connectionString),
+    max: 5,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 5_000,
+  });
+
+  pool.on('error', (err) => {
+    logger.error('Unexpected database pool error:', err);
+  });
+
+  return pool;
+}
+
+export async function closePool(): Promise<void> {
+  if (!pool) return;
+  poolClosed = true;
+  const p = pool;
+  pool = null;
+  try {
+    await p.end();
+  } catch (error) {
+    logger.warn('Error while closing database pool:', error);
+  }
+}

--- a/backend/src/services/marketsApiSerialize.ts
+++ b/backend/src/services/marketsApiSerialize.ts
@@ -125,6 +125,7 @@ export function serializeReserveForApi(reserve: RuntimeReserveData): MarketWithS
     ...(reserve.spokeId ? { spokeId: reserve.spokeId } : {}),
     ...(reserve.spokeName ? { spokeName: reserve.spokeName } : {}),
     ...(reserve.spokeAddress ? { spokeAddress: reserve.spokeAddress } : {}),
+    ...((reserve as any).priceSource ? { priceSource: (reserve as any).priceSource as 'sdk' | 'oracle' } : {}),
   };
   return out;
 }

--- a/backend/src/services/marketsService.ts
+++ b/backend/src/services/marketsService.ts
@@ -24,6 +24,7 @@ import {
   calculateBaseRateFallback,
   type OnchainReserveData,
 } from './onchainDataService.js';
+import { getV3OraclePrice, getV4OraclePrice } from './oracleService.js';
 
 // Timeout for markets fetch (Aave API can be slow)
 const MARKETS_FETCH_TIMEOUT_MS = 60_000; // 60 seconds
@@ -129,6 +130,35 @@ export async function refreshMarketsSnapshot(): Promise<MarketsSnapshot> {
         }
       }
 
+      // Oracle price override: if oracle diff > 1%, use oracle price
+      let oracleOverrideCount = 0;
+      for (const reserve of payload.data) {
+        let oraclePrice: number | undefined;
+
+        if (reserve.spokeAddress) {
+          oraclePrice = getV4OraclePrice(reserve.chainId, reserve.spokeAddress, reserve.tokenAddress);
+        } else {
+          oraclePrice = getV3OraclePrice(reserve.chainId, reserve.tokenAddress);
+        }
+
+        if (oraclePrice === undefined) continue;
+
+        const sdkPrice = reserve.tokenPrice;
+        if (sdkPrice === undefined || sdkPrice === 0) {
+          reserve.tokenPrice = oraclePrice;
+          (reserve as any).priceSource = 'oracle';
+          oracleOverrideCount++;
+          continue;
+        }
+
+        const diff = Math.abs(oraclePrice - sdkPrice) / sdkPrice;
+        if (diff > 0.01) {
+          reserve.tokenPrice = oraclePrice;
+          (reserve as any).priceSource = 'oracle';
+          oracleOverrideCount++;
+        }
+      }
+
       const newSnapshot: MarketsSnapshot = {
         payload,
         fetchedAt: Date.now(),
@@ -140,6 +170,7 @@ export async function refreshMarketsSnapshot(): Promise<MarketsSnapshot> {
       logger.info(
         `✅ Markets refresh: ${payload.data.length} reserves in ${elapsed}ms ` +
         `(on-chain: ${mergedCount} merged, ${fallbackCount} fallback, ` +
+        `oracle: ${oracleOverrideCount} overridden, ` +
         `cache: ${cacheStatus.freshPools}/${cacheStatus.poolCount} fresh)`
       );
 

--- a/backend/src/services/oracleService.ts
+++ b/backend/src/services/oracleService.ts
@@ -508,3 +508,11 @@ export function getV4OraclePrice(chainId: number, spokeAddress: string, tokenAdd
   if (!isLeanCacheFresh()) return undefined;
   return leanPriceCache.get(`${chainId}:${spokeAddress.toLowerCase()}:${tokenAddress.toLowerCase()}`);
 }
+
+/**
+ * Returns the most recent full oracle snapshot, or null if not yet warmed.
+ * Read-only — never triggers a refresh.
+ */
+export function getCachedOraclePricesSnapshot(): OraclePricesSnapshot | null {
+  return cachedSnapshot;
+}

--- a/backend/src/services/oracleService.ts
+++ b/backend/src/services/oracleService.ts
@@ -1,0 +1,510 @@
+/**
+ * Oracle Price Service - Fetches AaveOracle prices for V3 and V4 reserves
+ *
+ * Architecture:
+ * - V3: 24 oracle instances across 14 independent chains (Ethereum has 4)
+ * - V4: 10 spoke-level oracle instances on Ethereum only (per-spoke prices)
+ * - Cron-write / API-read-only pattern (same as onchainDataService)
+ * - Memory cache with 30s TTL (oracle prices update ~every block)
+ * - Debug output: data/debug/oracle-prices.json
+ */
+
+import { Contract, providers } from 'ethers';
+import { getAaveRpcUrlsByChainId } from '@internal/aave-shared-config';
+import { withTimeout } from '../lib/timeout.js';
+import { ethProviderService } from './ethProviderService.js';
+import { logger } from '../logger.js';
+import { BACKEND_CACHE_TTL_MS } from '../cacheTtl.js';
+import { mkdir, rename, writeFile } from 'fs/promises';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const DEBUG_FILE = resolve(REPO_ROOT, 'data', 'debug', 'oracle-prices.json');
+
+const ORACLE_RPC_TIMEOUT_MS = 15_000;
+
+async function writeJsonAtomic(
+  filePath: string,
+  value: unknown,
+  replacer?: (key: string, value: unknown) => unknown,
+): Promise<void> {
+  const payload = JSON.stringify(value, replacer as any, 2);
+  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(tempPath, payload, 'utf-8');
+  await rename(tempPath, filePath);
+}
+
+// ============================================================
+// V3 Pool ABI (minimal: getReservesList)
+// ============================================================
+const V3_POOL_ABI = [
+  {
+    inputs: [],
+    name: 'getReservesList',
+    outputs: [{ internalType: 'address[]', name: '', type: 'address[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+// ============================================================
+// V3 Oracle ABI (minimal: getAssetsPrices)
+// ============================================================
+const V3_ORACLE_ABI = [
+  {
+    inputs: [{ internalType: 'address[]', name: 'assets', type: 'address[]' }],
+    name: 'getAssetsPrices',
+    outputs: [{ internalType: 'uint256[]', name: '', type: 'uint256[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+// ============================================================
+// V4 Spoke ABI (minimal: getReserveCount + getReserve)
+// ============================================================
+const V4_SPOKE_ABI = [
+  {
+    inputs: [],
+    name: 'getReserveCount',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'reserveId', type: 'uint256' }],
+    name: 'getReserve',
+    outputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'underlying', type: 'address' },
+          { internalType: 'address', name: 'hub', type: 'address' },
+          { internalType: 'uint16', name: 'assetId', type: 'uint16' },
+          { internalType: 'uint8', name: 'decimals', type: 'uint8' },
+          { internalType: 'uint24', name: 'collateralRisk', type: 'uint24' },
+          { internalType: 'uint8', name: 'flags', type: 'uint8' },
+          { internalType: 'uint32', name: 'dynamicConfigKey', type: 'uint32' },
+        ],
+        internalType: 'struct ISpoke.Reserve',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+// ============================================================
+// V4 Oracle ABI (minimal: getReservesPrices)
+// ============================================================
+const V4_ORACLE_ABI = [
+  {
+    inputs: [{ internalType: 'uint256[]', name: 'reserveIds', type: 'uint256[]' }],
+    name: 'getReservesPrices',
+    outputs: [{ internalType: 'uint256[]', name: '', type: 'uint256[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+// ============================================================
+// V3 Pool Configs (from AaveOracle-V3-价格读取指南.md)
+// ============================================================
+interface V3PoolConfig {
+  poolKey: string;
+  chainId: number;
+  chainName: string;
+  poolAddress: string;
+  oracleAddress: string;
+}
+
+const V3_POOL_CONFIGS: V3PoolConfig[] = [
+  { poolKey: 'AaveV3Ethereum', chainId: 1, chainName: 'Ethereum', poolAddress: '0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2', oracleAddress: '0x54586bE62E3c3580375aE3723C145253060Ca0C2' },
+  { poolKey: 'AaveV3EthereumLido', chainId: 1, chainName: 'Ethereum', poolAddress: '0x4e033931ad43597d96D6bcc25c280717730B58B1', oracleAddress: '0xE3C061981870C0C7b1f3C4F4bB36B95f1F260BE6' },
+  { poolKey: 'AaveV3EthereumEtherFi', chainId: 1, chainName: 'Ethereum', poolAddress: '0x0AA97c284e98396202b6A04024F5E2c65026F3c0', oracleAddress: '0x43b64f28A678944E0655404B0B98E443851cC34F' },
+  { poolKey: 'AaveV3EthereumHorizon', chainId: 1, chainName: 'Ethereum', poolAddress: '0xAe05Cd22df81871bc7cC2a04BeCfb516bFe332C8', oracleAddress: '0x985BcfAB7e0f4EF2606CC5b64FC1A16311880442' },
+  { poolKey: 'AaveV3Arbitrum', chainId: 42161, chainName: 'Arbitrum', poolAddress: '0x794a61358D6845594F94dc1DB02A252b5b4814aD', oracleAddress: '0xb56c2F0B653B2e0b10C9b928C8580Ac5Df02C7C7' },
+  { poolKey: 'AaveV3Avalanche', chainId: 43114, chainName: 'Avalanche', poolAddress: '0x794a61358D6845594F94dc1DB02A252b5b4814aD', oracleAddress: '0xEBd36016B3eD09D4693Ed4251c67Bd858c3c7C9C' },
+  { poolKey: 'AaveV3Base', chainId: 8453, chainName: 'Base', poolAddress: '0xA238Dd80C259a72e81d7e4664a9801593F98d1c5', oracleAddress: '0x2Cc0Fc26eD4563A5ce5e8bdcfe1A2878676Ae156' },
+  { poolKey: 'AaveV3BNB', chainId: 56, chainName: 'BNB', poolAddress: '0x6807dc923806fE8Fd134338EABCA509979a7e0cB', oracleAddress: '0x39bc1bfDa2130d6Bb6DBEfd366939b4c7aa7C697' },
+  { poolKey: 'AaveV3Celo', chainId: 42220, chainName: 'Celo', poolAddress: '0x3E59A31363E2ad014dcbc521c4a0d5757d9f3402', oracleAddress: '0x1e693D088ceFD1E95ba4c4a5F7EeA41a1Ec37e8b' },
+  { poolKey: 'AaveV3Gnosis', chainId: 100, chainName: 'Gnosis', poolAddress: '0xb50201558B00496A145fE76f7424749556E326D8', oracleAddress: '0xeb0a051be10228213BAEb449db63719d6742F7c4' },
+  { poolKey: 'AaveV3Linea', chainId: 59144, chainName: 'Linea', poolAddress: '0xc47b8C00b0f69a36fa203Ffeac0334874574a8Ac', oracleAddress: '0xCFDAdA7DCd2e785cF706BaDBC2B8Af5084d595e9' },
+  { poolKey: 'AaveV3Mantle', chainId: 5000, chainName: 'Mantle', poolAddress: '0x458F293454fE0d67EC0655f3672301301DD51422', oracleAddress: '0x47a063CfDa980532267970d478EC340C0F80E8df' },
+  { poolKey: 'AaveV3MegaETH', chainId: 4326, chainName: 'MegaETH', poolAddress: '0x7e324AbC5De01d112AfC03a584966ff199741C28', oracleAddress: '0x421117D7319E96d831972b3F7e970bbfe29C4F21' },
+  { poolKey: 'AaveV3Metis', chainId: 1088, chainName: 'Metis', poolAddress: '0x90df02551bB792286e8D4f13E0e357b4Bf1D6a57', oracleAddress: '0x38D36e85E47eA6ff0d18B0adF12E5fC8984A6f8e' },
+  { poolKey: 'AaveV3Optimism', chainId: 10, chainName: 'Optimism', poolAddress: '0x794a61358D6845594F94dc1DB02A252b5b4814aD', oracleAddress: '0xD81eb3728a631871a7eBBaD631b5f424909f0c77' },
+  { poolKey: 'AaveV3Polygon', chainId: 137, chainName: 'Polygon', poolAddress: '0x794a61358D6845594F94dc1DB02A252b5b4814aD', oracleAddress: '0xb023e699F5a33916Ea823A16485e259257cA8Bd1' },
+  { poolKey: 'AaveV3Plasma', chainId: 9745, chainName: 'Plasma', poolAddress: '0x925a2A7214Ed92428B5b1B090F80b25700095e12', oracleAddress: '0x33E0b3fc976DC9C516926BA48CfC0A9E10a2aAA5' },
+  { poolKey: 'AaveV3Scroll', chainId: 534352, chainName: 'Scroll', poolAddress: '0x11fCfe756c05AD438e312a7fd934381537D3cFfe', oracleAddress: '0x04421D8C506E2fA2371a08EfAaBf791F624054F3' },
+  { poolKey: 'AaveV3Soneium', chainId: 1868, chainName: 'Soneium', poolAddress: '0xDd3d7A7d03D9fD9ef45f3E587287922eF65CA38B', oracleAddress: '0x20040a64612555042335926d72B4E5F667a67fA1' },
+  { poolKey: 'AaveV3Sonic', chainId: 146, chainName: 'Sonic', poolAddress: '0x5362dBb1e601abF3a4c14c22ffEdA64042E5eAA3', oracleAddress: '0xD63f7658C66B2934Bd234D79D06aEF5290734B30' },
+  { poolKey: 'AaveV3XLayer', chainId: 196, chainName: 'XLayer', poolAddress: '0xE3F3Caefdd7180F884c01E57f65Df979Af84f116', oracleAddress: '0x91FC11136d5615575a0fC5981Ab5C0C54418E2C6' },
+  { poolKey: 'AaveV3zkSync', chainId: 324, chainName: 'zkSync', poolAddress: '0x78e30497a3c7527d953c6B1E3541b021A98Ac43c', oracleAddress: '0xC7F58Fca663a8d377B6D0c9703C697f56dC40088' },
+  { poolKey: 'AaveV3Harmony', chainId: 1666600000, chainName: 'Harmony', poolAddress: '0x794a61358D6845594F94dc1DB02A252b5b4814aD', oracleAddress: '0x3C90887Ede8D65ccb2777A5d577beAb2548280AD' },
+  { poolKey: 'AaveV3Ink', chainId: 57073, chainName: 'Ink', poolAddress: '0x2816cf15F6d2A220E789aA011D5EE4eB6c47FEbA', oracleAddress: '0x4758213271BFdC72224A7a8742dC865fC97756e1' },
+];
+
+// ============================================================
+// V4 Spoke Configs (from AaveOracle-V4-Price-Fetch.md, Ethereum only)
+// ============================================================
+interface V4SpokeConfig {
+  spokeName: string;
+  chainId: number;
+  chainName: string;
+  spokeAddress: string;
+  oracleAddress: string;
+}
+
+const V4_SPOKE_CONFIGS: V4SpokeConfig[] = [
+  { spokeName: 'BLUECHIP_SPOKE', chainId: 1, chainName: 'Ethereum', spokeAddress: '0x973a023A77420ba610f06b3858aD991Df6d85A08', oracleAddress: '0xdA1266a7b8620819dAE3F8bd6B546Da36e505bB8' },
+  { spokeName: 'MAIN_SPOKE', chainId: 1, chainName: 'Ethereum', spokeAddress: '0x94e7A5dCbE816e498b89aB752661904E2F56c485', oracleAddress: '0x99B2B6CEa9C3D2fd8F4d90f86741C44B212a6127' },
+  { spokeName: 'ETHENA_CORRELATED_SPOKE', chainId: 1, chainName: 'Ethereum', spokeAddress: '0x58131E79531caB1d52301228d1f7b842F26B9649', oracleAddress: '0x9b91a0943CADf554742E8Fb358B1cC4ae4F85F01' },
+  { spokeName: 'ETHENA_ECOSYSTEM_SPOKE', chainId: 1, chainName: 'Ethereum', spokeAddress: '0xba1B3D55D249692b669A164024A838309B7508AF', oracleAddress: '0xc390dbe9fc00D6db73C52d375642b47008C33c90' },
+  { spokeName: 'ETHERFI_E_SPOKE', chainId: 1, chainName: 'Ethereum', spokeAddress: '0xbF10BDfE177dE0336aFD7fcCF80A904E15386219', oracleAddress: '0xd8B153FaAA8f2b1bC774916FEd333A4F3dE48792' },
+  { spokeName: 'LIDO_E_SPOKE', chainId: 1, chainName: 'Ethereum', spokeAddress: '0xe1900480ac69f0B296841Cd01cC37546d92F35Cd', oracleAddress: '0x664D73b6C3591333Fd79510f7ce9ef81228824F5' },
+  { spokeName: 'KELP_E_SPOKE', chainId: 1, chainName: 'Ethereum', spokeAddress: '0x3131FE68C4722e726fe6B2819ED68e514395B9a4', oracleAddress: '0x37C316996C714Bf906743071e04E62220b3271ac' },
+  { spokeName: 'FOREX_SPOKE', chainId: 1, chainName: 'Ethereum', spokeAddress: '0xD8B93635b8C6d0fF98CbE90b5988E3F2d1Cd9da1', oracleAddress: '0xB3CE6E7b6d389a66eA4a3777bA07219d00FB3a9D' },
+  { spokeName: 'GOLD_SPOKE', chainId: 1, chainName: 'Ethereum', spokeAddress: '0x65407b940966954b23dfA3caA5C0702bB42984DC', oracleAddress: '0x0083421fd178749af2201ddA5A7C3feB5790B80c' },
+  { spokeName: 'LOMBARD_BTC_SPOKE', chainId: 1, chainName: 'Ethereum', spokeAddress: '0x7EC68b5695e803e98a21a9A05d744F28b0a7753D', oracleAddress: '0x198Cac7f54FFc7d709Ac0FEc4B6454CE73e21D3D' },
+];
+
+// ============================================================
+// Data Types
+// ============================================================
+
+export interface OraclePriceEntry {
+  rawPrice: string;
+  priceUsd: number;
+}
+
+export interface V3OraclePoolResult {
+  poolKey: string;
+  chainId: number;
+  oracleAddress: string;
+  assets: Record<string, OraclePriceEntry>; // key = assetAddress (lowercase)
+}
+
+export interface V4OracleSpokeResult {
+  spokeName: string;
+  chainId: number;
+  spokeAddress: string;
+  oracleAddress: string;
+  reserves: Record<number, OraclePriceEntry>; // key = reserveId
+  /** Mapping from reserveId (string) to underlying token address (lowercase) */
+  reserveTokens: Record<string, string>;
+}
+
+export interface OraclePricesSnapshot {
+  version: 'v3+v4';
+  updatedAt: number;
+  updatedAtISO: string;
+  v3: V3OraclePoolResult[];
+  v4: V4OracleSpokeResult[];
+}
+
+// ============================================================
+// In-Memory Cache
+// ============================================================
+
+/** Full snapshot for debug output */
+let cachedSnapshot: OraclePricesSnapshot | null = null;
+/** Lean price lookup: "chainId:tokenAddr" → priceUsd (V3 + V4 merged) */
+let leanPriceCache: Map<string, number> = new Map();
+let leanPriceUpdatedAt = 0;
+/** V4 reserveToken mapping cache: spokeKey → { tokens, updatedAt } (1h TTL) */
+const V4_RESERVE_TOKEN_TTL_MS = 3_600_000; // 1 hour
+const V4_RESERVE_TOKEN_CACHE = new Map<string, { tokens: Record<string, string>; updatedAt: number }>();
+let refreshInProgress: Promise<void> | null = null;
+
+// ============================================================
+// V3 Fetch
+// ============================================================
+
+async function fetchV3PoolPrices(
+  config: V3PoolConfig,
+  provider: providers.Provider,
+  rpcUrl: string
+): Promise<V3OraclePoolResult> {
+  const poolContract = new Contract(config.poolAddress, V3_POOL_ABI, provider);
+  const oracleContract = new Contract(config.oracleAddress, V3_ORACLE_ABI, provider);
+
+  const assets: string[] = await withTimeout(
+    poolContract.getReservesList(),
+    ORACLE_RPC_TIMEOUT_MS,
+    `V3 Pool getReservesList timeout for ${config.poolKey} via ${rpcUrl}`
+  ) as string[];
+
+  const rawPrices: string[] = (
+    await withTimeout(
+      oracleContract.getAssetsPrices(assets),
+      ORACLE_RPC_TIMEOUT_MS,
+      `V3 Oracle getAssetsPrices timeout for ${config.poolKey} via ${rpcUrl}`
+    ) as any[]
+  ).map((p: any) => p.toString());
+
+  const priceMap: Record<string, OraclePriceEntry> = {};
+  for (let i = 0; i < assets.length; i++) {
+    const addr = assets[i].toLowerCase();
+    const raw = rawPrices[i];
+    priceMap[addr] = {
+      rawPrice: raw,
+      priceUsd: Number(raw) / 1e8,
+    };
+  }
+
+  return {
+    poolKey: config.poolKey,
+    chainId: config.chainId,
+    oracleAddress: config.oracleAddress,
+    assets: priceMap,
+  };
+}
+
+// ============================================================
+// V4 Fetch
+// ============================================================
+
+async function fetchV4SpokePrices(
+  config: V4SpokeConfig,
+  provider: providers.Provider,
+  rpcUrl: string
+): Promise<V4OracleSpokeResult> {
+  const spokeContract = new Contract(config.spokeAddress, V4_SPOKE_ABI, provider);
+  const oracleContract = new Contract(config.oracleAddress, V4_ORACLE_ABI, provider);
+
+  const reserveCountBN = await withTimeout(
+    spokeContract.getReserveCount(),
+    ORACLE_RPC_TIMEOUT_MS,
+    `V4 Spoke getReserveCount timeout for ${config.spokeName} via ${rpcUrl}`
+  ) as any;
+
+  const reserveCount = Number(reserveCountBN);
+  if (reserveCount === 0) {
+    return {
+      spokeName: config.spokeName,
+      chainId: config.chainId,
+      spokeAddress: config.spokeAddress,
+      oracleAddress: config.oracleAddress,
+      reserves: {},
+      reserveTokens: {},
+    };
+  }
+
+  const reserveIds = Array.from({ length: reserveCount }, (_, i) => i);
+  const rawPrices: string[] = (
+    await withTimeout(
+      oracleContract.getReservesPrices(reserveIds),
+      ORACLE_RPC_TIMEOUT_MS,
+      `V4 Oracle getReservesPrices timeout for ${config.spokeName} via ${rpcUrl}`
+    ) as any[]
+  ).map((p: any) => p.toString());
+
+  const priceMap: Record<number, OraclePriceEntry> = {};
+  for (let i = 0; i < reserveIds.length; i++) {
+    const raw = rawPrices[i];
+    priceMap[reserveIds[i]] = {
+      rawPrice: raw,
+      priceUsd: Number(raw) / 1e8,
+    };
+  }
+
+  // Reserve token mapping: use cached version if fresh, else fetch on-chain
+  const spokeKey = `${config.chainId}:${config.spokeAddress.toLowerCase()}`;
+  const cachedMapping = V4_RESERVE_TOKEN_CACHE.get(spokeKey);
+  const now = Date.now();
+  let reserveTokens: Record<string, string>;
+
+  if (cachedMapping && (now - cachedMapping.updatedAt) < V4_RESERVE_TOKEN_TTL_MS) {
+    reserveTokens = cachedMapping.tokens;
+  } else {
+    reserveTokens = {};
+    const reserveResults = await Promise.allSettled(
+      reserveIds.map((rid) =>
+        withTimeout(
+          spokeContract.getReserve(rid),
+          ORACLE_RPC_TIMEOUT_MS,
+          `V4 Spoke getReserve(${rid}) timeout for ${config.spokeName}`
+        ) as any
+      )
+    );
+    reserveResults.forEach((r, i) => {
+      if (r.status === 'fulfilled') {
+        reserveTokens[String(reserveIds[i])] = (r.value.underlying as string).toLowerCase();
+      } else {
+        logger.debug(`⚠️  Oracle V4: Failed to fetch reserve ${reserveIds[i]} details for ${config.spokeName}`);
+      }
+    });
+    V4_RESERVE_TOKEN_CACHE.set(spokeKey, { tokens: reserveTokens, updatedAt: now });
+  }
+
+  return {
+    spokeName: config.spokeName,
+    chainId: config.chainId,
+    spokeAddress: config.spokeAddress,
+    oracleAddress: config.oracleAddress,
+    reserves: priceMap,
+    reserveTokens,
+  };
+}
+
+// ============================================================
+// Main Refresh
+// ============================================================
+
+export async function refreshOracleCache(): Promise<void> {
+  if (refreshInProgress) {
+    logger.debug('Oracle cache refresh already in progress, skipping');
+    return;
+  }
+
+  refreshInProgress = (async () => {
+    try {
+      const startTime = Date.now();
+
+      const v3Results: V3OraclePoolResult[] = [];
+      const v4Results: V4OracleSpokeResult[] = [];
+
+      // ============================================================
+      // Fetch all V3 pools and V4 spokes in parallel, each with RPC retry
+      // ============================================================
+
+      async function fetchV3WithRetry(config: V3PoolConfig): Promise<V3OraclePoolResult | null> {
+        const rpcUrls = getAaveRpcUrlsByChainId(config.chainId);
+        if (rpcUrls.length === 0) {
+          logger.debug(`⏭️  Oracle V3: Skipping ${config.poolKey} (chain ${config.chainId}), no RPC URLs`);
+          return null;
+        }
+        const candidates = ethProviderService.getProvidersForChain(config.chainId, rpcUrls);
+        if (candidates.length === 0) {
+          logger.warn(`⏭️  Oracle V3: Skipping ${config.poolKey} (chain ${config.chainId}), no healthy RPC`);
+          return null;
+        }
+        for (const candidate of candidates) {
+          try {
+            const result = await fetchV3PoolPrices(config, candidate.provider, candidate.rpcUrl);
+            ethProviderService.reportProviderSuccess(config.chainId, candidate.rpcUrl);
+            logger.debug(`✅ Oracle V3: ${config.poolKey} - ${Object.keys(result.assets).length} assets via ${candidate.rpcUrl}`);
+            return result;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            ethProviderService.reportProviderFailure(config.chainId, candidate.rpcUrl, message);
+            logger.warn(`❌ Oracle V3: ${config.poolKey} failed via ${candidate.rpcUrl}: ${message}`);
+          }
+        }
+        logger.warn(`❌ Oracle V3: ${config.poolKey} failed on all RPC candidates`);
+        return null;
+      }
+
+      async function fetchV4WithRetry(config: V4SpokeConfig): Promise<V4OracleSpokeResult | null> {
+        const rpcUrls = getAaveRpcUrlsByChainId(config.chainId);
+        if (rpcUrls.length === 0) {
+          logger.debug(`⏭️  Oracle V4: Skipping ${config.spokeName} (chain ${config.chainId}), no RPC URLs`);
+          return null;
+        }
+        const candidates = ethProviderService.getProvidersForChain(config.chainId, rpcUrls);
+        if (candidates.length === 0) {
+          logger.warn(`⏭️  Oracle V4: Skipping ${config.spokeName} (chain ${config.chainId}), no healthy RPC`);
+          return null;
+        }
+        for (const candidate of candidates) {
+          try {
+            const result = await fetchV4SpokePrices(config, candidate.provider, candidate.rpcUrl);
+            ethProviderService.reportProviderSuccess(config.chainId, candidate.rpcUrl);
+            logger.debug(`✅ Oracle V4: ${config.spokeName} - ${Object.keys(result.reserves).length} reserves via ${candidate.rpcUrl}`);
+            return result;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            ethProviderService.reportProviderFailure(config.chainId, candidate.rpcUrl, message);
+            logger.warn(`❌ Oracle V4: ${config.spokeName} failed via ${candidate.rpcUrl}: ${message}`);
+          }
+        }
+        logger.warn(`❌ Oracle V4: ${config.spokeName} failed on all RPC candidates`);
+        return null;
+      }
+
+      const v3Settled = await Promise.allSettled(V3_POOL_CONFIGS.map(fetchV3WithRetry));
+      for (const s of v3Settled) {
+        if (s.status === 'fulfilled' && s.value) v3Results.push(s.value);
+      }
+
+      const v4Settled = await Promise.allSettled(V4_SPOKE_CONFIGS.map(fetchV4WithRetry));
+      for (const s of v4Settled) {
+        if (s.status === 'fulfilled' && s.value) v4Results.push(s.value);
+      }
+
+      const now = Date.now();
+      cachedSnapshot = {
+        version: 'v3+v4',
+        updatedAt: now,
+        updatedAtISO: new Date(now).toISOString(),
+        v3: v3Results,
+        v4: v4Results,
+      };
+
+      // Build lean price cache: "chainId:tokenAddr" → priceUsd
+      const newLean = new Map<string, number>();
+      for (const pool of v3Results) {
+        for (const [addr, entry] of Object.entries(pool.assets)) {
+          newLean.set(`${pool.chainId}:${addr}`, entry.priceUsd);
+        }
+      }
+      for (const spoke of v4Results) {
+        for (const [ridStr, tokenAddr] of Object.entries(spoke.reserveTokens)) {
+          const entry = spoke.reserves[Number(ridStr)];
+          if (entry) {
+            newLean.set(`${spoke.chainId}:${spoke.spokeAddress.toLowerCase()}:${tokenAddr}`, entry.priceUsd);
+          }
+        }
+      }
+      leanPriceCache = newLean;
+      leanPriceUpdatedAt = now;
+
+      // Write debug file
+      try {
+        await writeJsonAtomic(DEBUG_FILE, cachedSnapshot, (_key: string, value: unknown) => {
+          if (typeof value === 'bigint') return value.toString();
+          return value;
+        });
+        logger.debug(`📄 Oracle prices written to ${DEBUG_FILE}`);
+      } catch (fileError) {
+        logger.warn(`⚠️  Failed to write oracle prices debug file: ${fileError instanceof Error ? fileError.message : String(fileError)}`);
+      }
+
+      const elapsed = Date.now() - startTime;
+      const totalV3Assets = v3Results.reduce((sum, r) => sum + Object.keys(r.assets).length, 0);
+      const totalV4Reserves = v4Results.reduce((sum, r) => sum + Object.keys(r.reserves).length, 0);
+      logger.info(`✅ Oracle cache refresh: ${v3Results.length} V3 pools (${totalV3Assets} assets), ${v4Results.length} V4 spokes (${totalV4Reserves} reserves) in ${elapsed}ms`);
+    } finally {
+      refreshInProgress = null;
+    }
+  })();
+
+  return refreshInProgress;
+}
+
+// ============================================================
+// Read Interface
+// ============================================================
+
+function isLeanCacheFresh(): boolean {
+  if (!leanPriceUpdatedAt) return false;
+  return (Date.now() - leanPriceUpdatedAt) < BACKEND_CACHE_TTL_MS.oracleTtlMs;
+}
+
+/** Get V3 token price by (chainId, tokenAddress), O(1). Returns undefined if stale or not found. */
+export function getV3OraclePrice(chainId: number, tokenAddress: string): number | undefined {
+  if (!isLeanCacheFresh()) return undefined;
+  return leanPriceCache.get(`${chainId}:${tokenAddress.toLowerCase()}`);
+}
+
+/** Get V4 token price by (chainId, spokeAddress, tokenAddress), O(1). Returns undefined if stale or not found. */
+export function getV4OraclePrice(chainId: number, spokeAddress: string, tokenAddress: string): number | undefined {
+  if (!isLeanCacheFresh()) return undefined;
+  return leanPriceCache.get(`${chainId}:${spokeAddress.toLowerCase()}:${tokenAddress.toLowerCase()}`);
+}

--- a/backend/src/services/persistenceService.ts
+++ b/backend/src/services/persistenceService.ts
@@ -1,0 +1,453 @@
+/**
+ * Persistence service — batch-writes market & oracle snapshots to PostgreSQL.
+ *
+ * Design highlights:
+ * - Throttled to once every PERSIST_INTERVAL_MS (default 5 min).
+ * - Skipped silently when DATABASE_URL is unset (treat persistence as opt-in).
+ * - Uses parameterised INSERT (`$1, $2, …`) — never string concatenation.
+ * - Idempotent via `ON CONFLICT (snapshot_ts, …) DO NOTHING` so a double
+ *   call after a process restart does not duplicate rows.
+ * - Failures only log a warning and never propagate, so persistence cannot
+ *   take down the cron-write/API-read-only main flow.
+ */
+import { getPool, isPersistenceEnabled } from './dbPool.js';
+import { logger } from '../logger.js';
+import type { MarketsPayload, RuntimeReserveData } from '../../../dist/index.js';
+import type { OraclePricesSnapshot } from './oracleService.js';
+
+const PERSIST_INTERVAL_MS = Number.parseInt(process.env.PERSIST_INTERVAL_MS ?? '', 10) || 5 * 60 * 1000;
+
+let lastPersistTs = 0;
+let lastPersistSuccessTs = 0;
+let lastErrorMessage: string | null = null;
+let totalMarketsRowsWritten = 0;
+let totalOracleRowsWritten = 0;
+let warnedDisabled = false;
+
+export interface PersistenceStatus {
+  enabled: boolean;
+  persistIntervalMs: number;
+  lastAttemptTs: number | null;
+  lastSuccessTs: number | null;
+  secondsSinceLastSuccess: number | null;
+  totalMarketsRowsWritten: number;
+  totalOracleRowsWritten: number;
+  lastError: string | null;
+}
+
+export function getPersistenceStatus(): PersistenceStatus {
+  return {
+    enabled: isPersistenceEnabled(),
+    persistIntervalMs: PERSIST_INTERVAL_MS,
+    lastAttemptTs: lastPersistTs || null,
+    lastSuccessTs: lastPersistSuccessTs || null,
+    secondsSinceLastSuccess: lastPersistSuccessTs
+      ? Math.round((Date.now() - lastPersistSuccessTs) / 1000)
+      : null,
+    totalMarketsRowsWritten,
+    totalOracleRowsWritten,
+    lastError: lastErrorMessage,
+  };
+}
+
+export interface PersistResult {
+  skipped: 'disabled' | 'throttled' | null;
+  marketsRowsWritten: number;
+  oracleRowsWritten: number;
+}
+
+export async function persistSnapshotIfNeeded(
+  payload: MarketsPayload | null,
+  oracleSnapshot: OraclePricesSnapshot | null
+): Promise<PersistResult> {
+  if (!isPersistenceEnabled()) {
+    if (!warnedDisabled) {
+      logger.info('💾 Persistence disabled (DATABASE_URL not set) — snapshots will not be saved');
+      warnedDisabled = true;
+    }
+    return { skipped: 'disabled', marketsRowsWritten: 0, oracleRowsWritten: 0 };
+  }
+
+  const now = Date.now();
+  if (now - lastPersistTs < PERSIST_INTERVAL_MS) {
+    return { skipped: 'throttled', marketsRowsWritten: 0, oracleRowsWritten: 0 };
+  }
+  // Set lastPersistTs upfront so a long-running write does not allow a second
+  // concurrent invocation from the next cron tick.
+  lastPersistTs = now;
+
+  // Use a single timestamp for both tables so cross-table joins line up.
+  const snapshotTs = new Date(now).toISOString();
+
+  let marketsRowsWritten = 0;
+  let oracleRowsWritten = 0;
+  let success = true;
+
+  if (payload && payload.data.length > 0) {
+    try {
+      marketsRowsWritten = await persistMarketSnapshot(payload, snapshotTs);
+    } catch (error) {
+      success = false;
+      lastErrorMessage = error instanceof Error ? error.message : String(error);
+      logger.warn('⚠️ Failed to persist market snapshot:', error);
+    }
+  }
+
+  if (oracleSnapshot) {
+    try {
+      oracleRowsWritten = await persistOraclePrices(oracleSnapshot, snapshotTs);
+    } catch (error) {
+      success = false;
+      lastErrorMessage = error instanceof Error ? error.message : String(error);
+      logger.warn('⚠️ Failed to persist oracle prices:', error);
+    }
+  }
+
+  if (success) {
+    lastPersistSuccessTs = now;
+    lastErrorMessage = null;
+    totalMarketsRowsWritten += marketsRowsWritten;
+    totalOracleRowsWritten += oracleRowsWritten;
+    logger.info(
+      `💾 Persisted snapshots: markets=${marketsRowsWritten} oracle=${oracleRowsWritten} ts=${snapshotTs}`
+    );
+  }
+
+  return { skipped: null, marketsRowsWritten, oracleRowsWritten };
+}
+
+// ---------------------------------------------------------------------------
+// Market snapshot writer
+// ---------------------------------------------------------------------------
+
+const MARKET_COLUMNS = [
+  'snapshot_ts', 'reserve_id', 'chain_id', 'chain_name', 'market_name',
+  'token_symbol', 'token_name', 'token_address', 'a_token_address', 'v_token_address',
+  'decimals', 'token_price', 'supply_apy', 'borrow_apy', 'utilization_pct',
+  'available_liquidity', 'total_variable_debt', 'reserve_size',
+  'supply_cap', 'borrow_cap', 'deficit',
+  'base_variable_borrow_rate', 'reserve_factor',
+  'variable_rate_slope1', 'variable_rate_slope2', 'optimal_usage_rate',
+  'supply_disabled', 'borrow_disabled', 'is_frozen', 'is_paused',
+  'supply_incentives_apr', 'borrow_incentives_apr', 'incentive_details',
+  'aave_pro_reserve_id',
+  'hub_id', 'hub_name', 'hub_address',
+  'spoke_id', 'spoke_name', 'spoke_address',
+] as const;
+
+async function persistMarketSnapshot(
+  payload: MarketsPayload,
+  snapshotTs: string
+): Promise<number> {
+  const pool = getPool();
+
+  const rows = payload.data.map((reserve) => buildMarketRow(reserve, snapshotTs));
+  if (rows.length === 0) return 0;
+
+  // Postgres caps parameters per statement at 65535. With ~39 columns we can
+  // safely send ~1600 rows; chunk anyway to be defensive.
+  const CHUNK = 500;
+  let written = 0;
+  for (let i = 0; i < rows.length; i += CHUNK) {
+    const chunk = rows.slice(i, i + CHUNK);
+    const { text, values } = buildBulkInsert(
+      'market_snapshots',
+      MARKET_COLUMNS as unknown as string[],
+      chunk,
+      'ON CONFLICT (snapshot_ts, reserve_id) DO NOTHING'
+    );
+    const result = await pool.query(text, values);
+    written += result.rowCount ?? 0;
+  }
+  return written;
+}
+
+function buildMarketRow(reserve: RuntimeReserveData, snapshotTs: string): unknown[] {
+  return [
+    snapshotTs,
+    reserve.reserveId,
+    reserve.chainId,
+    reserve.chainName,
+    reserve.marketName,
+    reserve.tokenSymbol,
+    reserve.tokenName,
+    reserve.tokenAddress,
+    reserve.aTokenAddress ?? null,
+    reserve.vTokenAddress ?? null,
+    reserve.decimals ?? null,
+    nullableNumber(reserve.tokenPrice),
+    nullableNumber(reserve.supplyApy),
+    nullableNumber(reserve.borrowApy),
+    nullableNumber(reserve.utilizationPct),
+    nullableBigintString(reserve.availableLiquidity),
+    nullableBigintString(reserve.totalVariableDebt),
+    nullableBigintString(reserve.reserveSize),
+    nullableBigintString(reserve.supplyCap),
+    nullableBigintString(reserve.borrowCap),
+    nullableBigintString(reserve.deficit),
+    nullableNumber(reserve.baseVariableBorrowRate),
+    nullableNumber(reserve.reserveFactor),
+    nullableNumber(reserve.variableRateSlope1),
+    nullableNumber(reserve.variableRateSlope2),
+    nullableNumber(reserve.optimalUsageRate),
+    reserve.supplyDisabled ?? null,
+    reserve.borrowDisabled ?? null,
+    reserve.isFrozen ?? null,
+    reserve.isPaused ?? null,
+    aggregateSupplyIncentivesApr(reserve),
+    aggregateBorrowIncentivesApr(reserve),
+    JSON.stringify(buildIncentiveDetails(reserve)),
+    reserve.aaveProReserveId ?? null,
+    reserve.hubId ?? null,
+    reserve.hubName ?? null,
+    reserve.hubAddress ?? null,
+    reserve.spokeId ?? null,
+    reserve.spokeName ?? null,
+    reserve.spokeAddress ?? null,
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Oracle writer
+// ---------------------------------------------------------------------------
+
+const ORACLE_COLUMNS = [
+  'snapshot_ts', 'chain_id', 'token_address', 'raw_price', 'price_usd', 'source', 'spoke_address',
+] as const;
+
+interface OracleRow {
+  snapshotTs: string;
+  chainId: number;
+  tokenAddress: string;
+  rawPrice: string;
+  priceUsd: number;
+  source: 'v3' | 'v4';
+  spokeAddress: string | null;
+}
+
+async function persistOraclePrices(
+  snap: OraclePricesSnapshot,
+  snapshotTs: string
+): Promise<number> {
+  const pool = getPool();
+
+  const rows: OracleRow[] = [];
+
+  for (const v3 of snap.v3) {
+    for (const [tokenAddr, entry] of Object.entries(v3.assets)) {
+      rows.push({
+        snapshotTs,
+        chainId: v3.chainId,
+        tokenAddress: tokenAddr.toLowerCase(),
+        rawPrice: entry.rawPrice,
+        priceUsd: entry.priceUsd,
+        source: 'v3',
+        spokeAddress: null,
+      });
+    }
+  }
+
+  for (const v4 of snap.v4) {
+    for (const [reserveIdStr, entry] of Object.entries(v4.reserves)) {
+      const tokenAddr = v4.reserveTokens[reserveIdStr];
+      if (!tokenAddr) continue;
+      rows.push({
+        snapshotTs,
+        chainId: v4.chainId,
+        tokenAddress: tokenAddr.toLowerCase(),
+        rawPrice: entry.rawPrice,
+        priceUsd: entry.priceUsd,
+        source: 'v4',
+        spokeAddress: v4.spokeAddress.toLowerCase(),
+      });
+    }
+  }
+
+  if (rows.length === 0) return 0;
+
+  // Deduplicate within a single batch to avoid `ON CONFLICT ... cannot affect
+  // row a second time` errors when the same key appears more than once.
+  const seen = new Set<string>();
+  const unique = rows.filter((r) => {
+    const key = `${r.chainId}|${r.tokenAddress}|${r.source}|${r.spokeAddress ?? ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  const CHUNK = 1000;
+  let written = 0;
+  for (let i = 0; i < unique.length; i += CHUNK) {
+    const chunk = unique.slice(i, i + CHUNK);
+    const tuples = chunk.map((r) => [
+      r.snapshotTs, r.chainId, r.tokenAddress, r.rawPrice, r.priceUsd, r.source, r.spokeAddress,
+    ]);
+    const { text, values } = buildBulkInsert(
+      'oracle_prices',
+      ORACLE_COLUMNS as unknown as string[],
+      tuples,
+      'ON CONFLICT (snapshot_ts, chain_id, token_address, source, spoke_address) DO NOTHING'
+    );
+    const result = await pool.query(text, values);
+    written += result.rowCount ?? 0;
+  }
+  return written;
+}
+
+// ---------------------------------------------------------------------------
+// SQL helpers
+// ---------------------------------------------------------------------------
+
+function buildBulkInsert(
+  table: string,
+  columns: string[],
+  rows: unknown[][],
+  onConflict: string
+): { text: string; values: unknown[] } {
+  const values: unknown[] = [];
+  const placeholders: string[] = [];
+  let i = 1;
+  for (const row of rows) {
+    if (row.length !== columns.length) {
+      throw new Error(`buildBulkInsert: row length ${row.length} != columns length ${columns.length}`);
+    }
+    const tuple = row.map(() => `$${i++}`).join(', ');
+    placeholders.push(`(${tuple})`);
+    values.push(...row);
+  }
+  const text =
+    `INSERT INTO ${table} (${columns.join(', ')}) VALUES ${placeholders.join(', ')} ${onConflict}`;
+  return { text, values };
+}
+
+function nullableNumber(v: unknown): number | null {
+  if (v === undefined || v === null) return null;
+  if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+  return v;
+}
+
+function nullableBigintString(v: unknown): string | null {
+  if (v === undefined || v === null || v === '') return null;
+  // Validate that it parses as integer-shaped string (allow leading minus).
+  const s = String(v);
+  if (!/^-?\d+$/.test(s)) return null;
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Incentive aggregation
+// ---------------------------------------------------------------------------
+
+/** Sum of all supply-side incentive APRs as a percentage (e.g. 5.5 = 5.5%). */
+export function aggregateSupplyIncentivesApr(reserve: RuntimeReserveData): number | null {
+  return aggregateIncentivesApr(
+    reserve.supplyIncentives,
+    reserve.meritSupplys,
+    reserve.merklSupplys,
+    reserve.brevisSupplys
+  );
+}
+
+/** Sum of all borrow-side incentive APRs as a percentage. */
+export function aggregateBorrowIncentivesApr(reserve: RuntimeReserveData): number | null {
+  return aggregateIncentivesApr(
+    reserve.borrowIncentives,
+    reserve.meritBorrows,
+    reserve.merklBorrows,
+    reserve.brevisBorrows
+  );
+}
+
+function aggregateIncentivesApr(
+  legacy: number[] | undefined,
+  merit: { apr?: number }[] | undefined,
+  merkl: { breakdowns?: { campaignApr?: number | null }[] }[] | undefined,
+  brevis: { breakdowns?: { campaignApr?: number | null }[] }[] | undefined
+): number | null {
+  let total = 0;
+  let any = false;
+
+  for (const v of legacy ?? []) {
+    if (Number.isFinite(v)) {
+      total += v * 100; // legacy ratios → percent
+      any = true;
+    }
+  }
+  for (const m of merit ?? []) {
+    if (typeof m.apr === 'number' && Number.isFinite(m.apr)) {
+      total += m.apr * 100; // merit apr is ratio
+      any = true;
+    }
+  }
+  for (const group of merkl ?? []) {
+    for (const b of group.breakdowns ?? []) {
+      if (typeof b.campaignApr === 'number' && Number.isFinite(b.campaignApr)) {
+        total += b.campaignApr * 100;
+        any = true;
+      }
+    }
+  }
+  for (const group of brevis ?? []) {
+    for (const b of group.breakdowns ?? []) {
+      if (typeof b.campaignApr === 'number' && Number.isFinite(b.campaignApr)) {
+        total += b.campaignApr * 100;
+        any = true;
+      }
+    }
+  }
+  return any ? Number(total.toFixed(6)) : null;
+}
+
+interface IncentiveDetails {
+  legacySupply?: number[];
+  legacyBorrow?: number[];
+  merit?: { side: 'supply' | 'borrow'; apr: number }[];
+  merkl?: { side: 'supply' | 'borrow' | 'hold'; aprs: number[] }[];
+  brevis?: { side: 'supply' | 'borrow'; aprs: number[] }[];
+}
+
+function buildIncentiveDetails(reserve: RuntimeReserveData): IncentiveDetails {
+  const out: IncentiveDetails = {};
+  if (reserve.supplyIncentives?.length) out.legacySupply = reserve.supplyIncentives;
+  if (reserve.borrowIncentives?.length) out.legacyBorrow = reserve.borrowIncentives;
+
+  const merit: IncentiveDetails['merit'] = [];
+  for (const m of reserve.meritSupplys ?? []) {
+    if (typeof m.apr === 'number') merit.push({ side: 'supply', apr: m.apr });
+  }
+  for (const m of reserve.meritBorrows ?? []) {
+    if (typeof m.apr === 'number') merit.push({ side: 'borrow', apr: m.apr });
+  }
+  if (merit.length) out.merit = merit;
+
+  const merkl: IncentiveDetails['merkl'] = [];
+  for (const [side, list] of [
+    ['supply', reserve.merklSupplys] as const,
+    ['borrow', reserve.merklBorrows] as const,
+    ['hold', reserve.merklHolds] as const,
+  ]) {
+    for (const group of list ?? []) {
+      const aprs = (group.breakdowns ?? [])
+        .map((b) => b.campaignApr)
+        .filter((v): v is number => typeof v === 'number');
+      if (aprs.length) merkl.push({ side, aprs });
+    }
+  }
+  if (merkl.length) out.merkl = merkl;
+
+  const brevis: IncentiveDetails['brevis'] = [];
+  for (const [side, list] of [
+    ['supply', reserve.brevisSupplys] as const,
+    ['borrow', reserve.brevisBorrows] as const,
+  ]) {
+    for (const group of list ?? []) {
+      const aprs = (group.breakdowns ?? [])
+        .map((b) => b.campaignApr)
+        .filter((v): v is number => typeof v === 'number');
+      if (aprs.length) brevis.push({ side, aprs });
+    }
+  }
+  if (brevis.length) out.brevis = brevis;
+
+  return out;
+}

--- a/backend/src/services/updateScheduler.ts
+++ b/backend/src/services/updateScheduler.ts
@@ -3,6 +3,7 @@ import { warmCoingeckoCategoriesCache, warmCoingeckoFdvCache } from '../controll
 import { warmCampaignForecastStatesCache } from '../controllers/merklForecastController.js';
 import { refreshMarketsSnapshot } from './marketsService.js';
 import { refreshOnchainCache } from './onchainDataService.js';
+import { refreshOracleCache } from './oracleService.js';
 import { logger } from '../logger.js';
 import { BACKEND_SCHEDULE_CRON } from '../cacheTtl.js';
 
@@ -18,6 +19,7 @@ export function startUpdateScheduler(): void {
   logger.info('📅 Starting cron schedulers (all cron-write/API-read-only):');
   logger.info('   • Markets (V3+V4 merged): every 1 minute at :00');
   logger.info('   • On-chain (deficit, baseRate): every 1 minute at :10 (30-min per-chain TTL)');
+  logger.info('   • Oracle (V3+V4 prices): every 60s (60s TTL, V4 reserveToken 1h cached)');
   logger.info('   • Forecast: every 10 minutes');
   logger.info('   • FDV: every 5 minutes');
   logger.info('   • Categories: every 6 hours');
@@ -40,6 +42,17 @@ export function startUpdateScheduler(): void {
     } catch (error) {
       logger.warn(
         `On-chain cache refresh failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  });
+
+  // Oracle price refresh every minute
+  schedule(BACKEND_SCHEDULE_CRON.oraclePriceWarmEveryMinuteAtSecond0, async () => {
+    try {
+      await refreshOracleCache();
+    } catch (error) {
+      logger.warn(
+        `Oracle cache refresh failed: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   });

--- a/backend/src/services/updateScheduler.ts
+++ b/backend/src/services/updateScheduler.ts
@@ -1,9 +1,11 @@
 import { schedule } from 'node-cron';
 import { warmCoingeckoCategoriesCache, warmCoingeckoFdvCache } from '../controllers/coingeckoController.js';
 import { warmCampaignForecastStatesCache } from '../controllers/merklForecastController.js';
-import { refreshMarketsSnapshot } from './marketsService.js';
+import { getMarketsSnapshot, refreshMarketsSnapshot } from './marketsService.js';
 import { refreshOnchainCache } from './onchainDataService.js';
-import { refreshOracleCache } from './oracleService.js';
+import { getCachedOraclePricesSnapshot, refreshOracleCache } from './oracleService.js';
+import { isPersistenceEnabled } from './dbPool.js';
+import { persistSnapshotIfNeeded } from './persistenceService.js';
 import { logger } from '../logger.js';
 import { BACKEND_SCHEDULE_CRON } from '../cacheTtl.js';
 
@@ -89,6 +91,27 @@ export function startUpdateScheduler(): void {
     } catch (error) {
       logger.warn(
         `Categories warm scheduler failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  });
+
+  // Persist snapshots to PostgreSQL — runs after markets/onchain/oracle have settled.
+  // Throttled internally; safely no-ops if DATABASE_URL is unset.
+  if (isPersistenceEnabled()) {
+    logger.info('   • Persistence flush: every 5 minutes at :30 (PostgreSQL)');
+  } else {
+    logger.info('   • Persistence flush: disabled (DATABASE_URL not set)');
+  }
+  schedule(BACKEND_SCHEDULE_CRON.persistenceFlushEveryFiveMinutesAtSecond30, async () => {
+    try {
+      const marketsSnapshot = getMarketsSnapshot();
+      const oracleSnapshot = getCachedOraclePricesSnapshot();
+      await persistSnapshotIfNeeded(marketsSnapshot?.payload ?? null, oracleSnapshot);
+    } catch (error) {
+      // persistSnapshotIfNeeded already swallows per-write errors; this catches
+      // anything before/around it (e.g. snapshot getter throwing unexpectedly).
+      logger.warn(
+        `Persistence scheduler failed: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   });

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -89,6 +89,7 @@ export interface MarketWithSpread {
   spokeId?: string;
   spokeName?: string;
   spokeAddress?: string;
+  priceSource?: 'sdk' | 'oracle';
 }
 
 export interface MarketsResponse {

--- a/backend/tests/persistenceService.test.ts
+++ b/backend/tests/persistenceService.test.ts
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  aggregateBorrowIncentivesApr,
+  aggregateSupplyIncentivesApr,
+} from '../src/services/persistenceService.js';
+import type { RuntimeReserveData } from '../../dist/index.js';
+
+function baseReserve(overrides: Partial<RuntimeReserveData> = {}): RuntimeReserveData {
+  return {
+    reserveId: 'Aave V3:1:0xdead',
+    marketName: 'Aave V3',
+    chainName: 'Ethereum',
+    chainId: 1,
+    tokenName: 'USD Coin',
+    tokenSymbol: 'USDC',
+    tokenAddress: '0xdead',
+    ...overrides,
+  };
+}
+
+test('aggregateSupplyIncentivesApr: returns null when no incentives present', () => {
+  assert.equal(aggregateSupplyIncentivesApr(baseReserve()), null);
+});
+
+test('aggregateSupplyIncentivesApr: legacy number[] is treated as ratios → percent', () => {
+  const r = baseReserve({ supplyIncentives: [0.01, 0.02] }); // 1% + 2%
+  assert.equal(aggregateSupplyIncentivesApr(r), 3);
+});
+
+test('aggregateSupplyIncentivesApr: sums merit + merkl + brevis (apr ratios → percent)', () => {
+  const r = baseReserve({
+    meritSupplys: [{ apr: 0.005 }] as RuntimeReserveData['meritSupplys'],
+    merklSupplys: [
+      { breakdowns: [{ campaignApr: 0.01 }, { campaignApr: 0.02 }] },
+    ] as unknown as RuntimeReserveData['merklSupplys'],
+    brevisSupplys: [
+      { breakdowns: [{ campaignApr: 0.005 }] },
+    ] as unknown as RuntimeReserveData['brevisSupplys'],
+  });
+  // (0.005 + 0.01 + 0.02 + 0.005) * 100 = 4
+  assert.equal(aggregateSupplyIncentivesApr(r), 4);
+});
+
+test('aggregateBorrowIncentivesApr: ignores non-finite apr values', () => {
+  const r = baseReserve({
+    borrowIncentives: [Number.NaN, 0.03],
+    meritBorrows: [{ apr: Number.POSITIVE_INFINITY }, { apr: 0.01 }] as RuntimeReserveData['meritBorrows'],
+  });
+  // 0.03 * 100 + 0.01 * 100 = 4
+  assert.equal(aggregateBorrowIncentivesApr(r), 4);
+});
+
+test('aggregateSupplyIncentivesApr: returns null when only non-finite values', () => {
+  const r = baseReserve({ supplyIncentives: [Number.NaN] });
+  assert.equal(aggregateSupplyIncentivesApr(r), null);
+});

--- a/docs/api/field-glossary.md
+++ b/docs/api/field-glossary.md
@@ -89,8 +89,73 @@
 | `spokeAddress` | 合约交互用（市场入口） |
 
 ---
+## 七、V4 SDK `borrowable` vs `canBorrow` 三层语义
 
-## 七、表头列与排序选项对照
+在 V4 SDK 原始响应（`/api/markets` 的数据源）中，每个 reserve 存在三个与「借款」相关的字段，
+分属不同层级，含义各不相同：
+
+### 1. `summary.borrowable` — 可用借款数量（Erc20Amount 对象）
+
+位于 `reserve.summary` 下，是 `__typename: "Erc20Amount"` 复杂对象，表示 **协议池子还剩多少可被借出**：
+
+```json
+"summary": {
+  "supplied":   { ... },   // 总存款
+  "borrowed":   { ... },   // 总借款
+  "borrowable": {           // 剩余流动性 = 存款 - 借款
+    "amount": { "onChainValue": "184229214", "value": "1.84229214" },
+    "exchange": { "value": "149934.6142", "name": "USD" }
+  }
+}
+```
+
+### 2. `settings.borrowable` — 协议风险配置开关（boolean）
+
+位于 `reserve.settings`（`ReserveSettings`），是管理员/治理配置的 **策略开关**——是否允许该资产被借出：
+
+```json
+"settings": {
+  "borrowable": false,   // false = 协议不允许借款
+  "collateral": true,
+  "suppliable": true
+}
+```
+
+> 对应合约层 Spoke `ReserveFlagsMap.borrowable`（位掩码 `0x04`），详见
+> [frozen-paused-semantics.md](../../../aaveapy-doc/frozen-paused-semantics.md#borrowable借款开关)。
+
+### 3. `canBorrow` — 运行时综合判断（boolean）
+
+位于 reserve 顶层，面向用户的 **最终综合判断**，合并了所有状态条件：
+
+```json
+"canBorrow": false,        // 综合结果：能借吗？
+"canSupply": true,
+"canUseAsCollateral": true
+```
+
+### 判断逻辑链
+
+```
+settings.borrowable = true
+  AND status.frozen = false
+  AND status.paused = false
+  AND status.active = true
+→ canBorrow = true
+```
+
+| 字段 | 位置 | 类型 | 含义 |
+|------|------|------|------|
+| `summary.borrowable` | 数据层 | `Erc20Amount` 对象 | 还剩多少可借（流动性数量） |
+| `settings.borrowable` | 配置层 | `boolean` | 协议是否允许借款（管理员开关） |
+| `canBorrow` | 运行时层 | `boolean` | 用户现在能不能借（综合判断） |
+
+> 可能 `settings.borrowable=true` 但 `canBorrow=false`（如资产被暂停），反之不可能。
+>
+> API 对外暴露 `borrowDisabled`（=`!canBorrow`的运行时值），不直接暴露 SDK 原始三层字段。
+
+---
+## 八、表头列与排序选项对照
 
 ```
 ┌─────────┬──────────┬────────┬──────────┬──────────┬──────────┐
@@ -134,7 +199,7 @@
 
 ---
 
-## 八、前端派生值计算公式
+## 九、前端派生值计算公式
 
 | 派生值 | 公式 | 代码位置 |
 |--------|------|---------|
@@ -149,7 +214,7 @@
 
 ---
 
-## 九、响应示例（字段 → 前端映射标注）
+## 十、响应示例（字段 → 前端映射标注）
 
 ```json
 {

--- a/docs/backend/oracle-price-service.md
+++ b/docs/backend/oracle-price-service.md
@@ -1,0 +1,137 @@
+# Oracle Price Service
+
+从链上 AaveOracle 合约批量获取 V3 + V4 市场价格，写入内存缓存 + `data/debug/oracle-prices.json`。
+
+## 架构
+
+```
+cron (每60秒) → refreshOracleCache()
+  ├── V3: 24 个 Pool (14 条独立链)
+  │     Pool.getReservesList() → AaveOracle.getAssetsPrices([])
+  │     匹配键: chainId:tokenAddr
+  ├── V4: 10 个 Spoke (全部在 Ethereum)
+  │     Spoke.getReserveCount() → AaveOracle.getReservesPrices([])
+  │     + reserveTokens 映射 (1h 缓存, 仅首刷/过期时调用 getReserve())
+  │     匹配键: chainId:spokeAddr:tokenAddr
+  ├── leanPriceCache (Map, O(1) 查询)
+  └── 输出: data/debug/oracle-prices.json
+```
+
+价格精度统一为 8 位小数 (1e8，Chainlink 标准)。
+
+## 关键文件
+
+| 文件 | 职责 |
+|---|---|
+| `backend/src/services/oracleService.ts` | V3/V4 oracle 获取 + 内存缓存 + debug 写入 |
+| `backend/src/cacheTtl.ts` | `oracleTtlMs: 30_000` + cron 表达式 |
+| `backend/src/services/updateScheduler.ts` | cron 调度注册 |
+| `backend/src/services/ethProviderService.ts` | RPC 提供者管理（健康追踪、失败回退） |
+| `packages/aave-shared-config/index.js` | 各链 RPC URL（含 Infura/Alchemy/Ankr 私有 key） |
+| `backend/src/env.ts` | 环境变量加载（dotenv → 私有 RPC key 注入） |
+| `data/debug/oracle-prices.json` | 运行时输出 (~50KB) |
+
+## 数据流
+
+1. **Cron 轮询**（60 秒间隔）
+2. 24 个 V3 Pool + 10 个 V4 Spoke **并行获取**（每池内部 RPC 重试回退）
+3. V4 reserveToken 映射 1h 缓存，避免每轮 63 次无效调用
+4. 写入内存 `cachedSnapshot` + `leanPriceCache`（TTL = 60 秒）
+5. 同步写入 `data/debug/oracle-prices.json`
+6. 通过 `getV3OraclePrice()` / `getV4OraclePrice()` 暴露 O(1) 查询
+
+## V3 Pool 映射（24 个实例）
+
+| Pool Key | Chain | Pool 地址 |
+|---|---|---|
+| AaveV3Ethereum | 1 (Ethereum) | `0x87870Bca...` |
+| AaveV3EthereumLido | 1 | `0x4e033931...` |
+| AaveV3EthereumEtherFi | 1 | `0x0AA97c28...` |
+| AaveV3EthereumHorizon | 1 | `0xAe05Cd22...` |
+| AaveV3Arbitrum | 42161 | `0x794a6135...` |
+| AaveV3Avalanche | 43114 | `0x794a6135...` |
+| AaveV3Base | 8453 | `0xA238Dd80...` |
+| AaveV3BNB | 56 | `0x6807dc92...` |
+| AaveV3Celo | 42220 | `0x3E59A313...` |
+| AaveV3Gnosis | 100 | `0xb5020155...` |
+| AaveV3Linea | 59144 | `0xc47b8C00...` |
+| AaveV3Mantle | 5000 | `0x458F2934...` |
+| AaveV3MegaETH | 4326 | `0x7e324AbC...` |
+| AaveV3Metis | 1088 | `0x90df0255...` |
+| AaveV3Optimism | 10 | `0x794a6135...` |
+| AaveV3Polygon | 137 | `0x794a6135...` |
+| AaveV3Plasma | 9745 | `0x925a2A72...` |
+| AaveV3Scroll | 534352 | `0x11fCfe75...` |
+| AaveV3Soneium | 1868 | `0xDd3d7A7d...` |
+| AaveV3Sonic | 146 | `0x5362dBb1...` |
+| AaveV3XLayer | 196 | `0xE3F3Caef...` |
+| AaveV3zkSync | 324 | `0x78e30497...` |
+| AaveV3Harmony | 1666600000 | `0x794a6135...` |
+| AaveV3Ink | 57073 | `0x2816cf15...` |
+
+## V4 Spoke 映射（10 个实例）
+
+| 地址 | 合约名 | Oracle 地址 |
+|---|---|---|
+| `0x973a02...` | BLUECHIP_SPOKE | `0xdA1266a7...` |
+| `0x94e7A5...` | MAIN_SPOKE | `0x99B2B6CE...` |
+| `0x58131E...` | ETHENA_CORRELATED_SPOKE | `0x9b91a094...` |
+| `0xba1B3D...` | ETHENA_ECOSYSTEM_SPOKE | `0xc390dbe9...` |
+| `0xbF10BD...` | ETHERFI_E_SPOKE | `0xd8B153Fa...` |
+| `0xe19004...` | LIDO_E_SPOKE | `0x664D73b6...` |
+| `0x3131FE...` | KELP_E_SPOKE | `0x37C31699...` |
+| `0xD8B936...` | FOREX_SPOKE | `0xB3CE6E7b...` |
+| `0x65407b...` | GOLD_SPOKE | `0x0083421f...` |
+| `0x7EC68b...` | LOMBARD_BTC_SPOKE | `0x198Cac7f...` |
+
+## RPC 重试机制
+
+每个 Pool/Spoke 获取顺序：
+1. 从 `ethProviderService.getProvidersForChain(chainId, rpcUrls)` 获取健康候选列表
+2. 按优先级依次尝试（公共 RPC 优先，私有 RPC 兜底）
+3. 成功 → `reportProviderSuccess`，失败 → `reportProviderFailure` + 尝试下一个
+4. 全部失败 → warn 日志
+
+私有 RPC key（`.env` 注入）：`INFURA_PROJECT_ID`、`ALCHEMY_API_KEY`、`ANKR_API_KEY`。
+
+## 与 onchainDataService 的关系
+
+两个服务独立，不整合：
+
+| 维度 | oracleService | onchainDataService |
+|---|---|---|---|
+| 合约 | AaveOracle (V3+V4) | UiPoolDataProvider |
+| 地址配置 | 硬编码静态列表 | AaveAddressBook 动态发现 |
+| 数据 | oracle 价格（USD） | deficit, baseVariableBorrowRate |
+| TTL | 60 秒 | 30 分钟 |
+| 刷新间隔 | 60 秒 | 1 分钟 |
+| reserveToken 映射 | 1 小时缓存（几乎不变） | — |
+
+**V4 reserveToken 两层 TTL 设计：** 价格每 60 秒刷新，但 `reserveId → tokenAddress` 映射 1 小时才重新查一次（只在 Aave 治理加减储备时才变化），避免每轮 63 次无效 `getReserve()` 调用。
+
+**注意：** `backend/src/env.ts` 必须用动态 `import('@internal/aave-shared-config')` 而非静态 import，否则 `dotenv.config()` 先于 shared-config 执行导致所有私有 RPC key 为 `undefined`。
+
+## 对外 API
+
+数据通过 cron-write/API-read-only 模式暴露：
+
+| 函数 | 用途 | 消费状态 |
+|---|---|---|
+| `refreshOracleCache()` | cron + 启动 warmup 写入 | ✅ updateScheduler + server.ts |
+| `getV3OraclePrice(chainId, tokenAddr)` | 查 V3 代币价格，O(1) | 待接入 |
+| `getV4OraclePrice(chainId, spokeAddr, tokenAddr)` | 查 V4 代币价格，O(1) | 待接入 |
+| `getOraclePricesFromCache()` | 拿完整 JSON snapshot | 待接入 |
+| `getLeanOracleCacheStatus()` | 查缓存健康状态 | 待接入 |
+| `getOracleCacheStatus()` | 查完整 snapshot 健康状态 | 待接入 |
+
+## 验证结果
+
+```
+V3:  275/275 SDK 代币匹配，0 SDK-only 缺口
+V4:   59/59  SDK 代币匹配，0 SDK-only 缺口
+P50 差异: 0.00%
+P99 差异: 0.16%
+Max 差异: 0.51% (Metis)
+```
+
+Oracle 链上价格与 Aave SDK API 价格完全一致，差异均在亚秒级刷新时差范围内。

--- a/docs/plans/2026-05-07-database-persistence-design.md
+++ b/docs/plans/2026-05-07-database-persistence-design.md
@@ -1,0 +1,531 @@
+# Database Persistence + Cloudflare R2 Backup — Design Doc
+
+**Date:** 2026-05-07
+**Status:** Implemented (see `feat/db-persistence-r2-backup`). The original draft below reflects the brainstormed design; revisions applied during implementation are summarised at the bottom of the file.
+**Author:** AI-assisted design session
+
+---
+
+## 1. 目标
+
+将后端关键时序数据持久化到数据库，支持历史趋势分析（APY 变化、utilization 趋势、价格历史等），同时通过 Cloudflare R2 做离线容灾备份。
+
+## 2. 技术选型
+
+| 组件 | 选型 | 月费 |
+|------|------|------|
+| 主存储 | Railway PostgreSQL | ~$5/月 (Hobby 计划) |
+| 写入层 | 新增 `persistenceService.ts`，每 5 分钟批量 INSERT | $0 |
+| 离线备份 | Cloudflare R2，每天 dump + 上传 | $0 |
+| **合计** | | **~$5/月** |
+
+### 为什么选 Railway PG 而非外部 VPS
+
+- Railway 内部网络延迟 <1ms，外部 VPS 需 10-100ms + 公网暴露风险
+- 运维零成本：自动备份、自动扩容、环境变量自动注入
+- 差价极小（$5 vs $3-5），不值得多出运维时间
+- 数据规模小（~15 MB/天），PG 完全胜任
+
+## 3. 整体架构
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                     现有架构 (不变)                        │
+│  ┌──────────┐  cron每1min  ┌──────────────────────────┐  │
+│  │ Aave API │──────────────▶│ marketsService (内存快照) │  │
+│  └──────────┘              └──────────────────────────┘  │
+│                                                           │
+│  ┌──────────┐  cron每1min  ┌──────────────────────────┐  │
+│  │ RPC 链上  │──────────────▶│ onchainDataService (内存) │  │
+│  └──────────┘              └──────────────────────────┘  │
+│                                                           │
+│  ┌──────────┐  cron每60s   ┌──────────────────────────┐  │
+│  │ Oracle   │──────────────▶│ oracleService (内存)      │  │
+│  └──────────┘              └──────────────────────────┘  │
+│                                                           │
+│  各 cron 刷新完成后,新增持久化步骤 (每5分钟节流一次)           │
+└─────────────────────────┬────────────────────────────────┘
+                          │ 每5分钟批量 INSERT
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│                  Railway PostgreSQL                       │
+│  ┌─────────────────────┐  ┌──────────────────────────┐   │
+│  │ market_snapshots    │  │ oracle_prices             │   │
+│  └─────────────────────┘  └──────────────────────────┘   │
+└─────────────────────────┬────────────────────────────────┘
+                          │ 每天凌晨: pg_dump → .sql.gz
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│               Cloudflare R2 (离线备份)                    │
+│          保留最近 30 天的 dump 文件                        │
+└──────────────────────────────────────────────────────────┘
+```
+
+## 4. 数据库 Schema
+
+### 4.1 `market_snapshots` — 市场快照
+
+每次刷新后所有 reserve 的核心指标。一张宽表，查询简单。
+
+```sql
+CREATE TABLE market_snapshots (
+    id              BIGSERIAL PRIMARY KEY,
+    snapshot_ts     TIMESTAMPTZ NOT NULL,          -- 快照时间
+    reserve_id      TEXT NOT NULL,                 -- "marketName:chainId:tokenAddress"
+    chain_id        INTEGER NOT NULL,
+    chain_name      TEXT NOT NULL,
+    market_name     TEXT NOT NULL,
+    token_symbol    TEXT NOT NULL,
+    token_name      TEXT NOT NULL,
+    token_address   TEXT NOT NULL,
+    token_price     NUMERIC(24, 8),               -- USD 价格
+    supply_apy      NUMERIC(12, 6),               -- supply APY (百分比)
+    borrow_apy      NUMERIC(12, 6),               -- borrow APY (百分比)
+    utilization_pct NUMERIC(8, 4),                -- 利用率 (百分比)
+    available_liquidity NUMERIC(40, 0),           -- 可用流动性 (raw wei)
+    total_variable_debt  NUMERIC(40, 0),          -- 总负债 (raw wei)
+    reserve_size    NUMERIC(40, 0),               -- 总存款 (raw wei)
+    supply_cap      NUMERIC(40, 0),               -- 存款上限 (raw wei)
+    borrow_cap      NUMERIC(40, 0),               -- 借款上限 (raw wei)
+    deficit         NUMERIC(40, 0),               -- 坏账 (raw wei)
+    base_variable_borrow_rate NUMERIC(12, 6),     -- 基础浮动借款利率 (百分比)
+    reserve_factor  NUMERIC(8, 4),                -- 储备金系数 (百分比)
+    variable_rate_slope1 NUMERIC(8, 4),
+    variable_rate_slope2 NUMERIC(8, 4),
+    optimal_usage_rate   NUMERIC(8, 4),
+    supply_disabled  BOOLEAN,
+    borrow_disabled  BOOLEAN,
+    is_frozen        BOOLEAN,
+    is_paused        BOOLEAN,
+    supply_incentives_apr NUMERIC(12, 6),         -- 所有 supply 激励加总
+    borrow_incentives_apr NUMERIC(12, 6),         -- 所有 borrow 激励加总
+    incentive_details JSONB,                      -- 激励明细 (JSON)
+    decimals         INTEGER,
+    hub_name         TEXT,                        -- V4 hub, V3=NULL
+    spoke_name       TEXT                         -- V4 spoke, V3=NULL
+);
+
+CREATE INDEX idx_market_snapshots_ts      ON market_snapshots (snapshot_ts DESC);
+CREATE INDEX idx_market_snapshots_reserve ON market_snapshots (reserve_id, snapshot_ts DESC);
+CREATE INDEX idx_market_snapshots_symbol  ON market_snapshots (token_symbol, snapshot_ts DESC);
+```
+
+### 4.2 `oracle_prices` — 预言机价格
+
+```sql
+CREATE TABLE oracle_prices (
+    id            BIGSERIAL PRIMARY KEY,
+    snapshot_ts   TIMESTAMPTZ NOT NULL,
+    chain_id      INTEGER NOT NULL,
+    token_address TEXT NOT NULL,                  -- lowercase
+    raw_price     NUMERIC(78, 0) NOT NULL,        -- oracle 原始值
+    price_usd     NUMERIC(24, 8) NOT NULL,        -- raw_price / 1e8
+    source        TEXT NOT NULL                   -- 'v3' | 'v4'
+);
+
+CREATE INDEX idx_oracle_prices_ts    ON oracle_prices (snapshot_ts DESC);
+CREATE INDEX idx_oracle_prices_token ON oracle_prices (chain_id, token_address, snapshot_ts DESC);
+```
+
+### 4.3 数据量估算
+
+| 表 | 每次行数 | 频率 | 每日 | 每月 | 约存储 |
+|----|---------|------|------|------|--------|
+| market_snapshots | ~550 | 每5min | ~16万行 | ~480万行 | ~450 MB/月 |
+| oracle_prices | ~300 | 每5min | ~8.6万行 | ~260万行 | |
+| **合计** | | | | | **~450 MB/月** |
+
+Railway Hobby 计划 5 GB 容量够存 ~10 个月数据。
+
+## 5. 写入逻辑
+
+### 5.1 写入时机：节流策略
+
+不每次 cron（1分钟）都写，每 5 分钟写入一次。
+
+```
+cron 每1分钟触发 refreshMarketsSnapshot()
+    │
+    ▼
+markets 数据刷新完毕
+    │
+    └── 检查距离上次 persist 是否 ≥ 5分钟
+            ├── 否 → 跳过
+            └── 是 → persistSnapshot()
+```
+
+### 5.2 核心实现
+
+新增文件: `backend/src/services/persistenceService.ts`
+
+```typescript
+import { getPool, sql } from './dbPool.js';
+import { logger } from '../logger.js';
+import type { MarketsPayload } from '../../../dist/index.js';
+import type { OraclePricesSnapshot } from './oracleService.js';
+
+let lastPersistTs = 0;
+const PERSIST_INTERVAL_MS = 5 * 60 * 1000; // 5 分钟
+
+export function getPersistenceStatus() {
+  return {
+    lastPersistTs: lastPersistTs || null,
+    persistIntervalMs: PERSIST_INTERVAL_MS,
+    secondsSinceLastPersist: lastPersistTs
+      ? Math.round((Date.now() - lastPersistTs) / 1000)
+      : null,
+  };
+}
+
+export async function persistSnapshotIfNeeded(
+  payload: MarketsPayload,
+  oracleSnapshot: OraclePricesSnapshot | null
+): Promise<{ marketsPersisted: boolean; oraclePersisted: boolean }> {
+  const now = Date.now();
+  if (now - lastPersistTs < PERSIST_INTERVAL_MS) {
+    return { marketsPersisted: false, oraclePersisted: false };
+  }
+
+  const result = { marketsPersisted: false, oraclePersisted: false };
+
+  try {
+    await persistMarketSnapshot(payload);
+    result.marketsPersisted = true;
+  } catch (error) {
+    logger.warn('⚠️ Failed to persist market snapshot:', error);
+  }
+
+  if (oracleSnapshot) {
+    try {
+      await persistOraclePrices(oracleSnapshot);
+      result.oraclePersisted = true;
+    } catch (error) {
+      logger.warn('⚠️ Failed to persist oracle prices:', error);
+    }
+  }
+
+  lastPersistTs = now;
+  return result;
+}
+
+async function persistMarketSnapshot(payload: MarketsPayload): Promise<void> {
+  const pool = getPool();
+  const now = new Date();
+  const snapshotTs = now.toISOString();
+
+  const rows = payload.data.map((reserve) => ({
+    snapshotTs,
+    reserveId: reserve.reserveId,
+    chainId: reserve.chainId,
+    chainName: reserve.chainName,
+    marketName: reserve.marketName,
+    tokenSymbol: reserve.tokenSymbol,
+    tokenName: reserve.tokenName,
+    tokenAddress: reserve.tokenAddress,
+    tokenPrice: reserve.tokenPrice ?? null,
+    supplyApy: reserve.supplyApy ?? null,
+    borrowApy: reserve.borrowApy ?? null,
+    utilizationPct: reserve.utilizationPct ?? null,
+    availableLiquidity: (reserve as any).availableLiquidity ?? null,
+    totalVariableDebt: (reserve as any).totalVariableDebt ?? null,
+    reserveSize: (reserve as any).reserveSize ?? null,
+    supplyCap: reserve.supplyCap ?? null,
+    borrowCap: reserve.borrowCap ?? null,
+    deficit: (reserve as any).deficit ?? null,
+    baseVariableBorrowRate: (reserve as any).baseVariableBorrowRate ?? null,
+    reserveFactor: reserve.reserveFactor ?? null,
+    variableRateSlope1: reserve.variableRateSlope1 ?? null,
+    variableRateSlope2: reserve.variableRateSlope2 ?? null,
+    optimalUsageRate: reserve.optimalUsageRate ?? null,
+    supplyDisabled: reserve.supplyDisabled ?? false,
+    borrowDisabled: reserve.borrowDisabled ?? false,
+    isFrozen: reserve.isFrozen ?? false,
+    isPaused: reserve.isPaused ?? false,
+    supplyIncentivesApr: aggregateIncentivesApr(reserve.supplyIncentives ?? []),
+    borrowIncentivesApr: aggregateIncentivesApr(reserve.borrowIncentives ?? []),
+    incentiveDetails: JSON.stringify(buildIncentiveDetails(reserve)),
+    decimals: reserve.decimals ?? null,
+    hubName: (reserve as any).hubName ?? null,
+    spokeName: (reserve as any).spokeName ?? null,
+  }));
+
+  if (rows.length === 0) return;
+
+  const columns = [
+    'snapshot_ts', 'reserve_id', 'chain_id', 'chain_name', 'market_name',
+    'token_symbol', 'token_name', 'token_address', 'token_price',
+    'supply_apy', 'borrow_apy', 'utilization_pct',
+    'available_liquidity', 'total_variable_debt', 'reserve_size',
+    'supply_cap', 'borrow_cap', 'deficit',
+    'base_variable_borrow_rate', 'reserve_factor',
+    'variable_rate_slope1', 'variable_rate_slope2', 'optimal_usage_rate',
+    'supply_disabled', 'borrow_disabled', 'is_frozen', 'is_paused',
+    'supply_incentives_apr', 'borrow_incentives_apr', 'incentive_details',
+    'decimals', 'hub_name', 'spoke_name',
+  ];
+
+  const values = rows.map((r) =>
+    `(${columns.map((col) => formatPgValue(r[toCamel(col)]))}).join(', ')`
+  );
+
+  const sql = `INSERT INTO market_snapshots (${columns.join(', ')}) VALUES ${values.join(', ')}`;
+  await pool.query(sql);
+
+  logger.info(`📊 Persisted ${rows.length} market snapshots to PostgreSQL`);
+}
+
+// 辅助函数略，完整实现在代码中
+```
+
+### 5.3 集成点
+
+在 `marketsService.ts` 的 `refreshMarketsSnapshot()` 末尾调用：
+
+```typescript
+// 在 snapshot 更新后
+import { persistSnapshotIfNeeded } from './persistenceService.js';
+import { getOraclePricesFromCache } from './oracleService.js';
+
+// ...snapshot = newSnapshot 之后...
+void persistSnapshotIfNeeded(newSnapshot.payload, getOraclePricesFromCache())
+  .then((r) => { if (r.marketsPersisted) logger.debug('Snapshot persisted'); });
+```
+
+**注意：** `void` 延迟执行，不阻塞 markets refresh 主流程。失败只打日志，不影响 API 服务。
+
+## 6. Cloudflare R2 离线备份
+
+### 6.1 策略
+
+| 项目 | 配置 |
+|------|------|
+| 触发 | 每天凌晨 03:00 UTC |
+| 内容 | `pg_dump --format=custom --compress=9` |
+| 保留 | 最近 30 天 |
+| 执行方式 | GitHub Actions (推荐) 或 Railway 内 cron |
+| 存储 | Cloudflare R2, bucket: `aave-db-backups` |
+
+### 6.2 实现：GitHub Actions（推荐）
+
+```yaml
+# .github/workflows/db-backup.yml
+name: Database Backup to R2
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # 每天 03:00 UTC
+  workflow_dispatch:       # 手动触发
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Connect to Railway PG
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          # 获取 DATABASE_URL 并通过 SSH 转发
+          railway link  # 需要项目 ID
+
+      - name: Dump database
+        run: |
+          pg_dump $DATABASE_URL --format=custom --compress=9 \
+            --file=backup-$(date +%Y-%m-%d).dump.gz
+
+      - name: Upload to Cloudflare R2
+        uses: actions/upload-artifact@v4
+        # 或用 aws CLI (S3 兼容):
+        run: |
+          aws s3 cp backup-*.dump.gz s3://aave-db-backups/ \
+            --endpoint-url ${{ secrets.R2_ENDPOINT }} \
+            --region auto
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+      - name: Cleanup old backups (>30 days)
+        run: |
+          aws s3 ls s3://aave-db-backups/ \
+            --endpoint-url ${{ secrets.R2_ENDPOINT }} \
+            --region auto \
+          | awk -v cutoff=$(date -d '30 days ago' +%Y-%m-%d) \
+            '$1 < cutoff {print $4}' \
+          | while read f; do
+              aws s3 rm "s3://aave-db-backups/$f" \
+                --endpoint-url ${{ secrets.R2_ENDPOINT }}
+            done
+```
+
+**GitHub Secrets 需配置：**
+
+| Secret | 说明 |
+|--------|------|
+| `RAILWAY_TOKEN` | Railway CLI 认证 token |
+| `R2_ENDPOINT` | `https://<account-id>.r2.cloudflarestorage.com` |
+| `R2_ACCESS_KEY_ID` | R2 S3 兼容 Access Key |
+| `R2_SECRET_ACCESS_KEY` | R2 S3 兼容 Secret Key |
+
+### 6.3 R2 一次性配置
+
+```bash
+# 1. Cloudflare Dashboard → R2 → Create Bucket
+#    Bucket: aave-db-backups
+
+# 2. Manage R2 API Tokens → Create API Token
+#    Permissions: Object Read & Write
+#    Generate: Access Key ID + Secret Access Key
+
+# 3. 测试上传
+aws s3 cp test.txt s3://aave-db-backups/ \
+  --endpoint-url https://<account-id>.r2.cloudflarestorage.com \
+  --region auto
+```
+
+### 6.4 费用
+
+| 项目 | 估值 | R2 免费额度 | 费用 |
+|------|------|------------|------|
+| 单日 dump (压缩) | ~5 MB | — | — |
+| 30 天保留 | ~150 MB | 10 GB | $0 |
+| 操作请求 | Class A/B 极少 | 大量免费 | $0 |
+| **总计** | | | **$0/月** |
+
+## 7. 连接池管理
+
+新增文件: `backend/src/services/dbPool.ts`
+
+使用 `pg` (node-postgres) 连接池：
+
+```typescript
+import { Pool } from 'pg';
+import { logger } from '../logger.js';
+
+let pool: Pool | null = null;
+
+export function getPool(): Pool {
+  if (!pool) {
+    if (!process.env.DATABASE_URL) {
+      throw new Error('DATABASE_URL environment variable is required for database persistence');
+    }
+
+    pool = new Pool({
+      connectionString: process.env.DATABASE_URL,
+      max: 5,                // 最多 5 个连接
+      idleTimeoutMillis: 30000,
+      connectionTimeoutMillis: 5000,
+    });
+
+    pool.on('error', (err) => {
+      logger.error('Unexpected database pool error:', err);
+    });
+  }
+
+  return pool;
+}
+
+export async function closePool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+```
+
+## 8. 查询示例
+
+### 某个 token 的 APY 历史趋势
+
+```sql
+SELECT snapshot_ts, supply_apy, borrow_apy, utilization_pct
+FROM market_snapshots
+WHERE token_symbol = 'USDC'
+  AND chain_name = 'Ethereum'
+  AND snapshot_ts > NOW() - INTERVAL '30 days'
+ORDER BY snapshot_ts;
+```
+
+### 所有链的 TVL 趋势（按 snapshot）
+
+```sql
+SELECT snapshot_ts,
+       SUM(reserve_size * token_price / 10^decimals) AS tvl_usd
+FROM market_snapshots
+WHERE snapshot_ts > NOW() - INTERVAL '7 days'
+GROUP BY snapshot_ts
+ORDER BY snapshot_ts;
+```
+
+### 价格变化
+
+```sql
+SELECT snapshot_ts, price_usd
+FROM oracle_prices
+WHERE token_address = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+  AND chain_id = 1
+ORDER BY snapshot_ts DESC
+LIMIT 100;
+```
+
+## 9. 数据保留策略（建议）
+
+| 时间范围 | 粒度 | 说明 |
+|----------|------|------|
+| 0-7 天 | 5 分钟级原始快照 | 精确分析 |
+| 8-90 天 | 1 小时聚合 | 降采样 |
+| 90+ 天 | 1 天聚合 | 长期趋势 |
+
+降采样可通过一个额外的 cron job 执行聚合 `INSERT INTO ... SELECT ... GROUP BY`。
+
+## 10. 实施步骤
+
+1. **Railway 配置** — Dashboard 添加 PostgreSQL 插件，获取 `DATABASE_URL`
+2. **创建表** — 在 PG 里执行 schema DDL
+3. **新增 `dbPool.ts`** — 连接池管理
+4. **新增 `persistenceService.ts`** — 批量写入逻辑
+5. **集成到 `marketsService.ts`** — refresh 末尾调用 persist
+6. **测试验证** — 本地跑 `npm --prefix backend run dev`，确认数据写入 PG
+7. **Cloudflare R2 配置** — 创建 bucket + API token
+8. **GitHub Actions** — 添加 `.github/workflows/db-backup.yml`，配置 Secrets
+9. **文档更新** — 更新 `docs/api/api-documentation.md` 补充 DB 查询说明
+
+## 11. 风险与应对
+
+| 风险 | 应对 |
+|------|------|
+| PG 写入失败 | 不影响 API 主流程，只打 warn 日志；R2 备份可兜底 |
+| DATABASE_URL 缺失 | `getPool()` 抛错，persist 跳过；环境不完整时不强制 |
+| 数据膨胀 | 保留策略 + 降采样；Hobby 5GB 够用至少 10 个月 |
+| Railway PG 不可用 | R2 每天备份可恢复；PG 挂了 API 照常服务（内存快照独立） |
+| 备份恢复耗时 | 每日 dump ~5MB，恢复 < 1 分钟 |
+
+## 12. 未来扩展（不做，仅记录）
+
+- **TimescaleDB 迁移** — 数据量超过百万行/天后，启用 hypertable 自动分区
+- **只读副本** — 分析查询走副本，不影响写入性能
+- **Grafana 看板** — 直接连 PG 做实时可视化
+
+---
+
+## 13. 实施期修订（2026-05-07）
+
+落地实现与第 4–7 章草稿存在以下差异，以代码为准：
+
+1. **SQL 拼接 → 参数化批量 INSERT**：`buildBulkInsert()` 生成 `$1,$2,...` 占位符，所有值通过 `pool.query(text, values)` 走参数化通道；草稿里的字符串拼接版本是 broken 的伪代码（`.join()` 写在了模板字符串内部），未采用。
+2. **幂等约束**：`market_snapshots` 加 `UNIQUE(snapshot_ts, reserve_id)`；`oracle_prices` 加 `UNIQUE(snapshot_ts, chain_id, token_address, source, spoke_address)`。所有 INSERT 走 `ON CONFLICT DO NOTHING`，进程重启或快照重复触发都不会产生重复行。
+3. **Schema 字段补齐**：补 `a_token_address / v_token_address / aave_pro_reserve_id / hub_id / hub_address / spoke_id / spoke_address`，去掉所有 `as any` 强转。
+4. **激励聚合修正**：草稿里 `aggregateIncentivesApr(reserve.supplyIncentives ?? [])` 只读了 legacy 的 `number[]`，丢失 merit/merkl/brevis；实现里改为对四类来源（legacy `supplyIncentives` 数组 + `meritSupplys.apr` + `merklSupplys.breakdowns[].campaignApr` + `brevisSupplys.breakdowns[].campaignApr`）求和，统一换算成百分比。注意 merkl/brevis 的字段是 `campaignApr`（来自 `BaseCampaignBreakdown`），不是 `apr`。
+5. **集成点改为独立 cron**：放弃在 `marketsService.refreshMarketsSnapshot` 末尾 `void` 触发，改在 [updateScheduler.ts](file:///Users/pabloli/Documents/code/aave-protocol-analysis/backend/src/services/updateScheduler.ts) 新增 `persistenceFlushEveryFiveMinutesAtSecond30`（每 5 分钟在 :30s 执行），统一拉取 markets/oracle 当前快照后写入，避免不同源刷新时间错位。
+6. **`DATABASE_URL` 缺失行为**：`isPersistenceEnabled()` 在 `persistSnapshotIfNeeded` 入口就 short-circuit 返回 `{ skipped: 'disabled' }`，启动时打一次 INFO，不再每次 cron warn。
+7. **新增 `/api/persistence-status` 监控端点**：暴露 `lastSuccessTs / secondsSinceLastSuccess / totalMarketsRowsWritten / totalOracleRowsWritten / lastError`，用于尽早发现静默失败。
+8. **graceful shutdown**：`server.ts` 注册 `SIGTERM/SIGINT` 处理器，先 `server.close()` 再 `closePool()`，10s 超时强退；解决 Railway 重启时 in-flight 写入被强杀的问题。
+9. **R2 备份 workflow 修正**：
+   - 不用 `railway link`（GH Actions 无法交互登录），改为直接 `pg_dump $DATABASE_URL_PUBLIC`，使用 Railway「Public Networking」公网连接串作为 GH Secret。
+   - 显式安装 `postgresql-client-17`（ubuntu-latest 自带的 16 和 Railway 的 17 不兼容会报 server version mismatch）。
+   - `aws s3 cp backup-*.dump.gz` 不支持 glob → 改用 `BACKUP_FILE` 环境变量传递明确文件名；同时去掉误导性的 `.gz` 后缀（`-Fc -Z9` 是 custom 格式自压缩，不是 gzip）。
+   - 30 天 retention 改为 R2 bucket 自带的 lifecycle rule，workflow 不再写删除逻辑（更可靠，跳过运行也不会撑爆 bucket）。
+10. **容量重新核算**：~28 列宽表 × 550 行 × 288 次/天 ≈ 60 MB/天 ≈ 1.8 GB/月（不是草稿里的 450 MB/月）。Railway Hobby 5 GB 实际只够 2.5–3 个月，落地后必须尽早实施第 9 章的降采样或考虑 TimescaleDB（草稿第 12 章）。
+
+参数化 INSERT 的并发上限、错误日志、SIGTERM 处理见 [persistenceService.ts](file:///Users/pabloli/Documents/code/aave-protocol-analysis/backend/src/services/persistenceService.ts) / [dbPool.ts](file:///Users/pabloli/Documents/code/aave-protocol-analysis/backend/src/services/dbPool.ts) / [server.ts](file:///Users/pabloli/Documents/code/aave-protocol-analysis/backend/src/server.ts)。

--- a/package-lock.json
+++ b/package-lock.json
@@ -955,9 +955,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -2235,12 +2235,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2756,9 +2756,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/packages/aave-shared-config/index.js
+++ b/packages/aave-shared-config/index.js
@@ -255,6 +255,19 @@ export const AAVE_RPC_URLS_BY_CHAIN_KEY = Object.freeze({
     'https://rpc.ankr.com/flare',
     `https://rpc.ankr.com/flare/${ANKR_API_KEY}`,
   ]),
+  xlayer: Object.freeze([
+    'https://rpc.xlayer.tech',
+    'https://xlayerrpc.okx.com',
+    'https://xlayer.drpc.org',
+    'https://1rpc.io/xlayer',
+  ]),
+  harmony: Object.freeze([
+    'https://api.harmony.one',
+    'https://rpc.ankr.com/harmony',
+    'https://harmony-0-rpc.gateway.pokt.network',
+    'https://1rpc.io/one',
+    `https://rpc.ankr.com/harmony/${ANKR_API_KEY}`,
+  ]),
 });
 
 export const AAVE_CHAIN_KEY_ALIASES = Object.freeze({
@@ -276,6 +289,7 @@ export const AAVE_CHAIN_ID_TO_RPC_KEY = Object.freeze({
   100: 'gnosis',
   137: 'polygon',
   146: 'sonic',
+  196: 'xlayer',
   324: 'zksync',
   1868: 'soneium',
   42220: 'celo',


### PR DESCRIPTION
Implements the design in `docs/plans/2026-05-07-database-persistence-design.md`, with the revisions captured in §13 of the same doc.

## What it does

- Persists market & oracle snapshots to PostgreSQL every 5 minutes via a new cron-driven `persistenceService`. Writes use parameterised batch INSERTs with `ON CONFLICT DO NOTHING`, so process restarts cannot create duplicates.
- Persistence is opt-in via `DATABASE_URL` — silent no-op when unset, never blocks the cron-write/API-read-only main flow on persistence failures.
- Daily `pg_dump` to Cloudflare R2 via GitHub Actions, relying on R2 bucket lifecycle for 30-day retention rather than scripted deletes.

## Notable implementation choices vs. the original draft

1. SQL is **parameterised** (`buildBulkInsert` produces `$1, $2, ...`); the draft's string-concat version had a bug (`.join()` inside the template string) and was unsafe.
2. Idempotent: `UNIQUE (snapshot_ts, reserve_id)` and `UNIQUE (snapshot_ts, chain_id, token_address, source, spoke_address)` plus `ON CONFLICT DO NOTHING`.
3. Schema covers `aTokenAddress`, `vTokenAddress`, `aaveProReserveId`, `hubId`, `hubAddress`, `spokeId`, `spokeAddress`; no `as any` casts.
4. Incentive aggregation correctly sums **legacy `supplyIncentives` array + merit `apr` + merkl `breakdowns[].campaignApr` + brevis `breakdowns[].campaignApr`** (the merkl/brevis field is `campaignApr` from `BaseCampaignBreakdown`, not `apr`).
5. Persistence runs from a **dedicated cron** (`persistenceFlushEveryFiveMinutesAtSecond30`) rather than tail-called from `refreshMarketsSnapshot`, so markets and oracle snapshots are written at the same `snapshot_ts` and never drift apart.
6. Adds `/api/persistence-status` so silent DB failures are caught quickly.
7. SIGTERM/SIGINT now drain HTTP and close the pg pool (10s hard timeout) — important for Railway redeploys.
8. Backup workflow uses public `DATABASE_URL` directly (no interactive `railway link`), installs `postgresql-client-17` to match Railway's PG 17, passes the dump filename via env var (no shell glob), and delegates retention to an R2 bucket lifecycle rule.

## Files

- `backend/migrations/001_init_persistence.sql`
- `backend/src/services/dbPool.ts`, `backend/src/services/persistenceService.ts`
- `backend/src/services/updateScheduler.ts`, `backend/src/services/oracleService.ts` (cron + snapshot getter)
- `backend/src/server.ts` (status endpoint + graceful shutdown)
- `backend/src/cacheTtl.ts` (new cron entry)
- `backend/tests/persistenceService.test.ts`
- `.github/workflows/db-backup.yml`
- `docs/plans/2026-05-07-database-persistence-design.md` (design + §13 revisions)

## Operator setup

1. Railway → add PostgreSQL plugin → `DATABASE_URL` is auto-injected.
2. Apply the schema: `psql "$DATABASE_URL" -f backend/migrations/001_init_persistence.sql`.
3. Watch `/api/persistence-status` after deploy: `lastSuccessTs` should advance every 5 minutes, `lastError` should stay `null`.
4. For backups: enable Railway PG public networking, create the R2 bucket + API token, add the four GH Secrets listed at the top of `db-backup.yml`, and configure a 30-day lifecycle rule on the bucket.

## Testing

- [x] `npm run build` (root)
- [x] `npm --prefix backend run build`
- [x] `npm --prefix backend run test` — 53/53 pass, includes 5 new `persistenceService` tests for incentive aggregation
- [x] `npm run prune` and `npm --prefix backend run prune`
- [x] Pre-commit `ci:remote` gate passed