### PR TITLE
chore(backend): align side-data cache-header s-maxage with current shortest TTL (AAV-366)

### DIFF
--- a/backend/src/middleware/cacheHeaders.ts
+++ b/backend/src/middleware/cacheHeaders.ts
@@ -3,8 +3,10 @@ import type { NextFunction, Request, Response } from 'express';
 const CACHE_CONTROL = {
   // Core real-time APIs: always revalidate to match frontend staleTime expectations.
   coreRealtime: 'no-cache, must-revalidate',
-  // Public side-data API with slower update cadence.
-  coingeckoFdv: 'public, max-age=60, s-maxage=300, stale-while-revalidate=300',
+  // Public side-data API (categories=6h, FDV=15m, forecast=10m); s-maxage aligned to
+  // the shortest source TTL (forecast=10m) so edge cache never serves data older than
+  // any individual source's freshness contract.
+  sideDataMeta: 'public, max-age=60, s-maxage=600, stale-while-revalidate=600',
   // Never cache health checks.
   noStore: 'no-store',
 } as const;
@@ -31,8 +33,7 @@ export function apiCacheHeadersMiddleware(req: Request, res: Response, next: Nex
   }
 
   if (path.startsWith('/api/meta/side-data')) {
-    // Meta payload contains FDV (5m), forecast (10m), and categories (6h); use the shortest TTL.
-    setCacheControlIfMissing(res, CACHE_CONTROL.coingeckoFdv);
+    setCacheControlIfMissing(res, CACHE_CONTROL.sideDataMeta);
     next();
     return;
   }


### PR DESCRIPTION
Closes AAV-366

## Summary

`backend/src/middleware/cacheHeaders.ts` referenced a stale constant for the `/api/meta/side-data` route: the inline comment claimed `FDV (5m)` while `cacheTtl.ts` has long set FDV to 15min. The s-maxage of 300s (5min) was therefore more conservative than necessary and didn't reflect the actual shortest source TTL.

## Changes

- Rename `CACHE_CONTROL.coingeckoFdv` → `sideDataMeta` (constant serves the merged side-data endpoint, not FDV specifically).
- Update comment to reflect current source TTLs: categories=6h, FDV=15m, forecast=10m, shortest=10m.
- Raise `s-maxage` from 300 to 600.
- Raise `stale-while-revalidate` from 300 to 600.

After this change, edge cache stays aligned with the actual shortest source TTL (forecast=10m).