### PR TITLE
ci(remediation): align self-check with canonical audit gate and escalate failures

### DIFF
--- a/.github/workflows/ci-auto-remediation.yml
+++ b/.github/workflows/ci-auto-remediation.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ci-auto-remediation-${{ github.event.workflow_run.head_branch || github.event.inputs.branch || 'default' }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   contents: write
@@ -29,7 +33,45 @@ jobs:
        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'pull_request'))
     runs-on: ubuntu-latest
     steps:
+      - name: Check if CI failure is ERESOLVE (unfixable by audit)
+        id: skip-check
+        if: github.event_name == 'workflow_run'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            core.setOutput('skip', 'false');
+            const runId = context.payload.workflow_run.id;
+            const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            for (const job of jobs) {
+              if (job.conclusion !== 'failure') continue;
+              let log;
+              try {
+                const resp = await github.rest.actions.downloadJobLogsForWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  job_id: job.id,
+                });
+                log = resp.data;
+              } catch (e) {
+                core.warning(`Could not download logs for job ${job.name} (id=${job.id}): ${e.message}. Assuming no ERESOLVE.`);
+                continue;
+              }
+              if (/npm error code ERESOLVE/.test(log)) {
+                core.setOutput('skip', 'true');
+                core.notice('CI failure contains ERESOLVE — peer dep conflict cannot be fixed by audit. Skipping.');
+                return;
+              }
+            }
+
+      - name: Skip remediation for ERESOLVE failures
+        if: steps.skip-check.outputs.skip == 'true'
+        run: exit 0
       - name: Resolve target branch
+        if: steps.skip-check.outputs.skip != 'true'
         id: branch
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.branch }}" ]; then
@@ -41,38 +83,46 @@ jobs:
           fi
 
       - name: Checkout target branch
+        if: steps.skip-check.outputs.skip != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ steps.branch.outputs.name }}
 
       - name: Setup Node
+        if: steps.skip-check.outputs.skip != 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "20"
           cache: "npm"
 
       - name: Install dependencies
+        if: steps.skip-check.outputs.skip != 'true'
         run: npm ci
 
       - name: Attempt dependency remediation
+        if: steps.skip-check.outputs.skip != 'true'
         run: |
           npm audit fix --omit=dev || true
-          npm --prefix backend audit fix --omit=dev || true
 
       - name: Reinstall dependencies for build verification
-        run: |
-          npm ci
-          npm --prefix backend ci
+        if: steps.skip-check.outputs.skip != 'true'
+        run: npm ci
 
       - name: Validate build after remediation
+        if: steps.skip-check.outputs.skip != 'true'
         id: verify
         run: |
           set +e
           npm run build
           BUILD_ROOT=$?
-          npm --prefix backend run build
+          npm run build -w aave-dashboard-backend
           BUILD_BACKEND=$?
-          if [ "$BUILD_ROOT" -eq 0 ] && [ "$BUILD_BACKEND" -eq 0 ]; then
+          # Use the SAME gate as CI (`npm run audit`): root high + backend moderate,
+          # with the shared GHSA allowlist. Mirroring CI guarantees we never open a
+          # PR that the canonical security-audit job will reject.
+          npm run audit
+          AUDIT=$?
+          if [ "$BUILD_ROOT" -eq 0 ] && [ "$BUILD_BACKEND" -eq 0 ] && [ "$AUDIT" -eq 0 ]; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "ok=false" >> "$GITHUB_OUTPUT"
@@ -80,6 +130,7 @@ jobs:
           exit 0
 
       - name: Check for generated changes
+        if: steps.skip-check.outputs.skip != 'true'
         id: diff
         run: |
           if git diff --quiet; then
@@ -90,7 +141,7 @@ jobs:
 
       - name: Create remediation PR
         id: cpr
-        if: steps.verify.outputs.ok == 'true' && steps.diff.outputs.changed == 'true'
+        if: steps.skip-check.outputs.skip != 'true' && steps.verify.outputs.ok == 'true' && steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
           commit-message: "chore: auto-remediate dependency issues after CI failure"
@@ -106,14 +157,13 @@ jobs:
 
             Actions performed:
             - `npm audit fix --omit=dev`
-            - `npm --prefix backend audit fix --omit=dev`
             - `npm run build`
-            - `npm --prefix backend run build`
+            - `npm run build -w aave-dashboard-backend`
           labels: ci-auto-remediation,dependencies
           base: ${{ steps.branch.outputs.name }}
 
       - name: Review and enable auto-merge for remediation PR
-        if: steps.cpr.outputs.pull-request-number != ''
+        if: steps.skip-check.outputs.skip != 'true' && steps.cpr.outputs.pull-request-number != ''
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.CODEX_BOT_TOKEN != '' && secrets.CODEX_BOT_TOKEN || github.token }}
@@ -156,4 +206,66 @@ jobs:
               );
             } catch (error) {
               core.warning(`Enable auto-merge failed for PR #${prNumber}: ${error.message}`);
+            }
+
+      # B2: When automated remediation cannot produce a passing fix (verify failed),
+      # `npm audit fix` is the wrong tool for this repo's override-based vuln pattern.
+      # Escalate to a human/agent via an issue instead of silently doing nothing.
+      - name: Read audit output for escalation
+        if: steps.skip-check.outputs.skip != 'true' && steps.verify.outputs.ok != 'true'
+        id: audit-out
+        run: |
+          {
+            echo 'report<<AUDIT_EOF'
+            echo '## Root audit (audit-level=high)'
+            echo '```'
+            cat /tmp/_audit1 2>/dev/null | tail -60 || echo '(no root audit output)'
+            echo '```'
+            echo '## Backend audit (audit-level=moderate)'
+            echo '```'
+            cat /tmp/_audit2 2>/dev/null | tail -60 || echo '(no backend audit output)'
+            echo '```'
+            echo AUDIT_EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Escalate via issue when remediation fails
+        if: steps.skip-check.outputs.skip != 'true' && steps.verify.outputs.ok != 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const branch = '${{ steps.branch.outputs.name }}';
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const title = `Auto-remediation could not fix CI security audit on \`${branch}\``;
+            const marker = '<!-- ci-auto-remediation-failed -->';
+            const body = [
+              marker,
+              `Automated \`npm audit fix\` could not produce a fix that passes the canonical \`npm run audit\` gate on \`${branch}\`.`,
+              '',
+              'This repo fixes transitive vulnerabilities via `overrides` in `package.json`, which `npm audit fix` cannot do correctly. A human or agent should bump the relevant `overrides` (root and/or `backend`) to safe versions, as in PR #136.',
+              '',
+              `Remediation run: ${runUrl}`,
+              '',
+              '<details><summary>Audit output</summary>',
+              '',
+              `${{ steps.audit-out.outputs.report }}`,
+              '',
+              '</details>',
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'ci-auto-remediation',
+            });
+            const found = existing.data.find((i) => i.body && i.body.includes(marker) && i.title === title);
+            if (found) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: found.number,
+                body: `Remediation failed again on \`${branch}\`.\n\nRun: ${runUrl}`,
+              });
+              core.notice(`Updated existing escalation issue #${found.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner, repo, title, body, labels: ['ci-auto-remediation', 'dependencies'],
+              });
+              core.notice(`Opened escalation issue #${created.data.number}`);
             }


### PR DESCRIPTION
## Summary

Hardens the CI auto-remediation workflow so it stops producing wrong/failing remediation PRs (e.g. #135).

### A) Align self-check with the canonical CI gate
The self-check previously ran `npm audit --audit-level=moderate` (root only, no allowlist) — a different gate than CI's `npm run audit` (root `high` + backend `moderate` + shared GHSA allowlist). That mismatch let the bot open PRs that the real `security-audit` job rejects. It now runs `npm run audit`, so the bot never opens a PR that CI will fail.

### B) Escalate instead of silently doing nothing
This repo fixes transitive vulnerabilities via `overrides`, which `npm audit fix` cannot do correctly. When remediation can't produce a passing fix, the workflow now opens/updates a `ci-auto-remediation` issue with the audit output so a human/agent can bump overrides (as in #136).

This branch also brings `main`'s copy of the workflow file in sync with the `railway` branch (concurrency group + ERESOLVE skip-check were already present there).