### PR TITLE
fix: cache key mismatch + free LLM model

### DIFF
--- a/backend/src/services/marketsService.ts
+++ b/backend/src/services/marketsService.ts
@@ -547,8 +547,8 @@ export function extractConstraintMap(reserves: RuntimeReserveData[]): Map<string
   const map = new Map<string, NetPositionConstraint | null>();
   for (const r of reserves) {
     for (const group of [...(r.merklSupplys ?? []), ...(r.merklBorrows ?? []), ...(r.merklHolds ?? [])]) {
-      if (group.link && 'netPositionConstraint' in group) {
-        map.set(group.link, group.netPositionConstraint ?? null);
+      if (group.opportunityId && 'netPositionConstraint' in group) {
+        map.set(group.opportunityId, group.netPositionConstraint ?? null);
       }
     }
   }

--- a/backend/tests/extractConstraintMap.test.ts
+++ b/backend/tests/extractConstraintMap.test.ts
@@ -19,12 +19,13 @@ function makeReserve(overrides: Partial<RuntimeReserveData> = {}): RuntimeReserv
   } as RuntimeReserveData;
 }
 
-test('extractConstraintMap collects netPositionConstraint from supply groups', () => {
+test('extractConstraintMap collects netPositionConstraint from supply groups using opportunityId', () => {
   const reserves: RuntimeReserveData[] = [
     makeReserve({
       merklSupplys: [
         {
-          link: 'opp-1',
+          opportunityId: '9623615825108171573',
+          link: 'https://app.merkl.xyz/opportunities/9623615825108171573',
           netPositionConstraint: { sourceSide: 'supply', offsetReserveIds: ['1:0xpool:0xusdt'] },
         } as any,
       ],
@@ -32,7 +33,8 @@ test('extractConstraintMap collects netPositionConstraint from supply groups', (
   ];
   const map = extractConstraintMap(reserves);
   assert.equal(map.size, 1);
-  assert.deepEqual(map.get('opp-1'), { sourceSide: 'supply', offsetReserveIds: ['1:0xpool:0xusdt'] });
+  assert.deepEqual(map.get('9623615825108171573'), { sourceSide: 'supply', offsetReserveIds: ['1:0xpool:0xusdt'] });
+  assert.equal(map.get('https://app.merkl.xyz/opportunities/9623615825108171573'), undefined);
 });
 
 test('extractConstraintMap collects from borrow and hold groups too', () => {
@@ -40,13 +42,15 @@ test('extractConstraintMap collects from borrow and hold groups too', () => {
     makeReserve({
       merklBorrows: [
         {
-          link: 'opp-borrow',
+          opportunityId: 'opp-borrow-id',
+          link: 'https://app.merkl.xyz/opportunities/opp-borrow-id',
           netPositionConstraint: { sourceSide: 'borrow', offsetReserveIds: ['1:0xpool:0xgho'] },
         } as any,
       ],
       merklHolds: [
         {
-          link: 'opp-hold',
+          opportunityId: 'opp-hold-id',
+          link: 'https://app.merkl.xyz/opportunities/opp-hold-id',
           netPositionConstraint: { sourceSide: 'supply', offsetReserveIds: ['1:0xpool:0xusde'] },
         } as any,
       ],
@@ -54,16 +58,16 @@ test('extractConstraintMap collects from borrow and hold groups too', () => {
   ];
   const map = extractConstraintMap(reserves);
   assert.equal(map.size, 2);
-  assert.deepEqual(map.get('opp-borrow'), { sourceSide: 'borrow', offsetReserveIds: ['1:0xpool:0xgho'] });
-  assert.deepEqual(map.get('opp-hold'), { sourceSide: 'supply', offsetReserveIds: ['1:0xpool:0xusde'] });
+  assert.deepEqual(map.get('opp-borrow-id'), { sourceSide: 'borrow', offsetReserveIds: ['1:0xpool:0xgho'] });
+  assert.deepEqual(map.get('opp-hold-id'), { sourceSide: 'supply', offsetReserveIds: ['1:0xpool:0xusde'] });
 });
 
-test('extractConstraintMap skips groups without netPositionConstraint or link', () => {
+test('extractConstraintMap skips groups without netPositionConstraint or opportunityId', () => {
   const reserves: RuntimeReserveData[] = [
     makeReserve({
       merklSupplys: [
-        { link: 'opp-no-constraint' } as any,
-        { netPositionConstraint: { sourceSide: 'supply', offsetReserveIds: [] } } as any,
+        { opportunityId: 'opp-no-constraint', link: 'opp-no-constraint' } as any,
+        { link: 'opp-no-id', netPositionConstraint: { sourceSide: 'supply', offsetReserveIds: [] } } as any,
       ],
     }),
   ];
@@ -74,4 +78,22 @@ test('extractConstraintMap skips groups without netPositionConstraint or link', 
 test('extractConstraintMap returns empty map for empty reserves', () => {
   const map = extractConstraintMap([]);
   assert.equal(map.size, 0);
+});
+
+test('extractConstraintMap key matches fetcher key format (opportunityId, not link)', () => {
+  const opportunityId = '1234567890123456789';
+  const reserves: RuntimeReserveData[] = [
+    makeReserve({
+      merklSupplys: [
+        {
+          opportunityId,
+          link: `https://app.merkl.xyz/opportunities/${opportunityId}`,
+          netPositionConstraint: { sourceSide: 'supply', offsetReserveIds: [] },
+        } as any,
+      ],
+    }),
+  ];
+  const map = extractConstraintMap(reserves);
+  assert.equal(map.has(opportunityId), true, 'key should be opportunityId (plain ID), not link (URL)');
+  assert.equal(map.has(`https://app.merkl.xyz/opportunities/${opportunityId}`), false, 'link format should NOT be a key');
 });

--- a/packages/aave-fetcher/src/merklLlmClient.ts
+++ b/packages/aave-fetcher/src/merklLlmClient.ts
@@ -12,31 +12,35 @@ export type LlmOutcome =
 import { logger } from './logger.js';
 
 /**
- * Default best-first chat-model allow-list (SiliconFlow-oriented).
+ * Default best-first chat-model allow-list (SiliconFlow free tier).
  *
- * ⚠️ IMPORTANT — this is a BEST-GUESS default, NOT a verified free list.
- * SiliconFlow's `GET /v1/models` returns only model `id`s (no pricing/free
- * flag) and there is no pricing endpoint, so free-vs-paid CANNOT be determined
- * programmatically. These ids are the models that have *historically* sat in
- * SiliconFlow's free tier (small ≤9B Qwen/GLM), but that can change and the
- * only authoritative source is your billing dashboard.
+ * ⚠️ HOW FREE-VS-PAID IS DETERMINED: SiliconFlow's `GET /v1/models` returns only
+ * model `id`s (no pricing/free flag) and there is no pricing API endpoint, so
+ * free-vs-paid CANNOT be determined programmatically. The authoritative source
+ * is the pricing page / model plaza (cloud.siliconflow.cn/models) and your
+ * billing dashboard. The ids below were verified "免费/free" against the pricing
+ * page + SiliconFlow's own free-tier announcements (checked 2026-07). Ordered
+ * best-first by a real net-position classification benchmark (accuracy, then
+ * latency):
+ *   - THUDM/GLM-4-9B-0414   free, 5/5 correct, ~0.5s  (instruct, no <think> → fast)
+ *   - THUDM/GLM-Z1-9B-0414  free, 5/5 correct, ~6.5s  (reasoning fallback)
+ *   - Qwen/Qwen3-8B         free, 5/5 correct, ~22s   (hybrid-thinking fallback)
+ * Excluded free-but-weak: Qwen2.5-7B-Instruct (2/5, malformed JSON),
+ * Hunyuan-MT-7B (1/5, translation model). Excluded paid: Qwen3.5-9B,
+ * DeepSeek-R1 (and its distill's free status is unconfirmed).
  *
- * To use models you have confirmed are free, set the `LLM_MODELS` env var
- * (comma-separated, best-first) — it overrides this list entirely. See
- * `resolveModelAllowList`.
+ * To pin the models your billing dashboard confirms are free, set the
+ * `LLM_MODELS` env var (comma-separated, best-first) — it overrides this list
+ * entirely. See `resolveModelAllowList`.
  *
  * The chain stays "real-time": `buildModelChain` intersects the allow-list with
  * the live `/models` response, so retired ids drop out and only currently
- * served models are called, in priority order. Reasoning-only distills (e.g.
- * DeepSeek-R1) are excluded — their long <think> output can overflow max_tokens
- * before the JSON answer.
+ * served models are called, in priority order.
  */
 export const LLM_FREE_MODELS = [
-  'Qwen/Qwen3.5-9B',
-  'Qwen/Qwen3-8B',
   'THUDM/GLM-4-9B-0414',
-  'Qwen/Qwen3.5-4B',
-  'Qwen/Qwen2.5-7B-Instruct',
+  'THUDM/GLM-Z1-9B-0414',
+  'Qwen/Qwen3-8B',
 ] as const;
 
 /**
@@ -264,11 +268,12 @@ export async function callLlmWithFallback(
               model,
               messages: [{ role: 'user', content: prompt }],
               temperature: 0,
-              max_tokens: 256,
-              // SiliconFlow extension: disable Qwen3 "thinking" so the model
-              // returns the JSON answer directly instead of long <think> output.
-              // Ignored by non-Qwen3 models.
-              enable_thinking: false,
+              // 2048 gives the reasoning fallbacks (GLM-Z1-9B, Qwen3-8B) room to
+              // finish <think> before the JSON answer. The primary GLM-4-9B is an
+              // instruct model that stops well short, so this adds no cost/latency
+              // for the common path. NOTE: do NOT send `enable_thinking: false` —
+              // GLM-Z1 rejects it, and GLM-4-9B doesn't need it.
+              max_tokens: 2048,
             }),
           }),
           new Promise<never>((_, reject) =>

--- a/packages/aave-fetcher/tests/merklLlmClient.test.ts
+++ b/packages/aave-fetcher/tests/merklLlmClient.test.ts
@@ -24,9 +24,12 @@ function mockFetch(responseBody: unknown, ok = true, contentType = 'application/
 }
 
 describe('B3: LLM client — model list + response parsing', () => {
-  it('LLM_FREE_MODELS lists the SiliconFlow free-tier chat models', () => {
+  it('LLM_FREE_MODELS lists the SiliconFlow free-tier chat models, best-first', () => {
     assert.ok(LLM_FREE_MODELS.length > 0);
-    assert.equal(LLM_FREE_MODELS[0], 'Qwen/Qwen3.5-9B');
+    // GLM-4-9B-0414 is the benchmarked best free model (5/5 correct, ~0.5s).
+    assert.equal(LLM_FREE_MODELS[0], 'THUDM/GLM-4-9B-0414');
+    // Paid models must never appear in the free default list.
+    assert.ok(!LLM_FREE_MODELS.includes('Qwen/Qwen3.5-9B' as never));
   });
 
   it('resolveModelAllowList defaults to LLM_FREE_MODELS', () => {
@@ -337,9 +340,9 @@ describe('buildModelChain — with dynamic primary models', () => {
     const fetch = async (url: string) => {
       if (url.includes('/models')) {
         return new Response(JSON.stringify({ data: [
-          { id: 'Qwen/Qwen3-8B' },          // free, lower priority
-          { id: 'deepseek-ai/DeepSeek-V4-Pro' }, // paid → must be excluded
-          { id: 'Qwen/Qwen3.5-9B' },        // free, top priority
+          { id: 'Qwen/Qwen3-8B' },               // free, lower priority
+          { id: 'deepseek-ai/DeepSeek-V4-Pro' },  // paid → must be excluded
+          { id: 'THUDM/GLM-4-9B-0414' },          // free, top priority
         ] }), {
           status: 200, headers: { 'content-type': 'application/json' },
         }) as Response;
@@ -348,8 +351,8 @@ describe('buildModelChain — with dynamic primary models', () => {
     };
     const chain = await buildModelChain(primary, fetch);
     const models = chain.map(c => c.model);
-    // Only free models, ordered by LLM_FREE_MODELS priority (3.5-9B before 3-8B).
-    assert.deepEqual(models, ['Qwen/Qwen3.5-9B', 'Qwen/Qwen3-8B']);
+    // Only free models, ordered by LLM_FREE_MODELS priority (GLM-4-9B before Qwen3-8B).
+    assert.deepEqual(models, ['THUDM/GLM-4-9B-0414', 'Qwen/Qwen3-8B']);
     assert.ok(!models.includes('deepseek-ai/DeepSeek-V4-Pro'), 'paid models must be excluded');
     resetPrimaryModelsCache();
   });


### PR DESCRIPTION
## Summary

- **fix: use opportunityId instead of link as cache key in extractConstraintMap** (`6a2fd2c`)
  - Backend `extractConstraintMap` used `group.link` (full URL) as Map key, while fetcher used `opp.opportunityId` (plain ID) — cache never hit, causing ~14,400 paid LLM calls/day
  - Aligned backend to use `group.opportunityId`, matching fetcher key format
  - After fix: only first cron cycle calls LLM (10x), subsequent cycles hit cache → 0 calls

- **fix(llm): correct SiliconFlow free-model default to verified free tier** (`7aa67ed`)
  - Default model list prioritized paid Qwen3.5-9B; reordered to use free GLM-4-9B-0414 first
  - All LLM calls now use free models, eliminating ~$1.50/day in API costs

## Verification

- Production deployed and verified via Railway SSH:
  - `enrich-llm calls=10` only on first cron cycle, then 0 for all subsequent cycles
  - All calls use `THUDM/GLM-4-9B-0414`, 0 calls to `Qwen/Qwen3.5-9B`